### PR TITLE
Changed to before/after date comparison

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -607,6 +607,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     new { Value = "GreaterThanOrEqual", Label = "Greater Than or Equal" },
                     new { Value = "LessThanOrEqual", Label = "Less Than or Equal" },
                     new { Value = "MatchRegex", Label = "Matches Regex (.NET syntax)" },
+                    new { Value = "After", Label = "After" },
+                    new { Value = "Before", Label = "Before" },
                     new { Value = "NewerThan", Label = "Newer Than" },
                     new { Value = "OlderThan", Label = "Older Than" }
                 },

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -464,11 +464,15 @@
                     op.Value === 'LessThanOrEqual'
                 );
             } else if (FIELD_TYPES.DATE_FIELDS.includes(fieldValue)) {
-                // Date fields can include all operators including date-specific ones
+                // Date fields: exclude string operators and numeric-specific operators, include date-specific operators
                 allowedOperators = availableFields.Operators.filter(op => 
                     op.Value !== 'Contains' && 
                     op.Value !== 'NotContains' && 
-                    op.Value !== 'MatchRegex'
+                    op.Value !== 'MatchRegex' &&
+                    op.Value !== 'GreaterThan' &&
+                    op.Value !== 'LessThan' &&
+                    op.Value !== 'GreaterThanOrEqual' &&
+                    op.Value !== 'LessThanOrEqual'
                 );
             } else if (FIELD_TYPES.BOOLEAN_FIELDS.includes(fieldValue) || FIELD_TYPES.SIMPLE_FIELDS.includes(fieldValue)) {
                 allowedOperators = availableFields.Operators.filter(op => op.Value === 'Equal' || op.Value === 'NotEqual');
@@ -1426,6 +1430,8 @@
                                         case 'NotContains': operator = "not contains"; break;
                                         case 'GreaterThan': operator = '>'; break;
                                         case 'LessThan': operator = '<'; break;
+                                        case 'After': operator = 'after'; break;
+                                        case 'Before': operator = 'before'; break;
                                         case 'GreaterThanOrEqual': operator = '>='; break;
                                         case 'LessThanOrEqual': operator = '<='; break;
                                         case 'MatchRegex': operator = 'matches regex'; break;
@@ -1691,6 +1697,8 @@
                                 case 'NotContains': operator = "not contains"; break;
                                 case 'GreaterThan': operator = '>'; break;
                                 case 'LessThan': operator = '<'; break;
+                                case 'After': operator = 'after'; break;
+                                case 'Before': operator = 'before'; break;
                                 case 'GreaterThanOrEqual': operator = '>='; break;
                                 case 'LessThanOrEqual': operator = '<='; break;
                                 case 'MatchRegex': operator = 'matches regex'; break;

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Engine.cs
@@ -293,9 +293,21 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             {
                 return (BinaryExpression)BuildWithinLastDaysExpression(r, left, logger);
             }
+            else if (r.Operator == "After")
+            {
+                logger?.LogDebug("SmartPlaylist 'After' operator for date field {Field} with timestamp {Timestamp}", r.MemberName, targetTimestamp);
+                var right = System.Linq.Expressions.Expression.Constant(targetTimestamp);
+                return System.Linq.Expressions.Expression.GreaterThan(left, right);
+            }
+            else if (r.Operator == "Before")
+            {
+                logger?.LogDebug("SmartPlaylist 'Before' operator for date field {Field} with timestamp {Timestamp}", r.MemberName, targetTimestamp);
+                var right = System.Linq.Expressions.Expression.Constant(targetTimestamp);
+                return System.Linq.Expressions.Expression.LessThan(left, right);
+            }
             else
             {
-                // For other operators (GreaterThan, LessThan, etc.), use the exact timestamp comparison
+                // For other operators (legacy .NET ExpressionType), use the exact timestamp comparison
                 if (Enum.TryParse(r.Operator, out ExpressionType dateBinary))
                 {
                     logger?.LogDebug("SmartPlaylist {Operator} IS a built-in ExpressionType for date field: {ExpressionType}", r.Operator, dateBinary);
@@ -305,7 +317,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 else
                 {
                     logger?.LogError("SmartPlaylist unsupported date operator '{Operator}' for field '{Field}'", r.Operator, r.MemberName);
-                    throw new ArgumentException($"Operator '{r.Operator}' is not supported for date field '{r.MemberName}'");
+                    throw new ArgumentException($"Operator '{r.Operator}' is not supported for date field '{r.MemberName}'. Supported operators: Equal, NotEqual, After, Before, NewerThan, OlderThan, WithinLastDays");
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ The web interface provides access to all available fields for creating playlist 
 ### Available Operators
 
 - **Equals** / **Not Equals** - Exact matches
-- **Contains** / **Not Contains** - Partial text matching
+- **Contains** / **Not Contains** - Partial text matching  
 - **Greater Than** / **Less Than** - Numeric comparisons
-- **Greater Than or Equal** / **Less Than or Equal** - Numeric comparisons (not available for date fields)
+- **Greater Than or Equal** / **Less Than or Equal** - Numeric comparisons
+- **After** / **Before** - Date comparisons
 - **Newer Than** / **Older Than** - Relative date comparisons (days, weeks, months, years)
 - **Matches Regex** - Advanced pattern matching using .NET regex syntax
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "After" and "Before" operators for date fields in smart playlist rules, allowing more flexible date-based filtering.

* **Bug Fixes**
  * Improved filtering logic to ensure only relevant operators are available for date fields.

* **Documentation**
  * Updated documentation to reflect the addition of "After" and "Before" operators and clarified operator availability for date fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->