### PR TITLE
- Fix: Artists fields now work properly

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -133,6 +133,9 @@ namespace Jellyfin.Plugin.SmartPlaylist
                         // Public status hasn't changed, just update the items
                         _logger.LogDebug("Updating smart playlist {PlaylistName} for user {User} with {ItemCount} items", smartPlaylistName, user.Username, newLinkedChildren.Length);
                         existingPlaylist.LinkedChildren = newLinkedChildren;
+                        
+                        // Note: Jellyfin defaults playlist MediaType to "Audio" regardless of content - this is a known Jellyfin limitation
+                        
                         await existingPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                         
                         // Refresh metadata to generate cover images
@@ -388,6 +391,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
             // Update the playlist items
             playlist.LinkedChildren = linkedChildren;
             
+            // Note: Jellyfin defaults playlist MediaType to "Audio" regardless of content - this is a known Jellyfin limitation
+            
             // Update the public status by setting the OpenAccess property
             var openAccessProperty = playlist.GetType().GetProperty("OpenAccess");
             if (openAccessProperty != null && openAccessProperty.CanWrite)
@@ -447,6 +452,9 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     newPlaylist.Name, newPlaylist.Shares?.Count ?? 0, newPlaylist.Shares.Any());
                 
                 newPlaylist.LinkedChildren = linkedChildren;
+                
+                // Note: Jellyfin defaults playlist MediaType to "Audio" regardless of content - this is a known Jellyfin limitation
+                
                 await newPlaylist.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken).ConfigureAwait(false);
                 
                 // Log the final state after update
@@ -562,6 +570,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 _logger.LogWarning(ex, "Failed to refresh metadata for playlist {PlaylistName} after {ElapsedTime}ms. Cover image may not be generated.", playlist.Name, stopwatch.ElapsedMilliseconds);
             }
         }
+
+
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -18,15 +18,15 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
 
         // Returns a specific operand povided a baseitem, user, and library manager object.
         public static Operand GetMediaType(ILibraryManager libraryManager, BaseItem baseItem, User user, 
-            IUserDataManager userDataManager = null, ILogger logger = null, bool extractAudioLanguages = false, bool extractPeople = false, bool extractArtists = false)
+            IUserDataManager userDataManager = null, ILogger logger = null, bool extractAudioLanguages = false, bool extractPeople = false)
         {
-            return GetMediaType(libraryManager, baseItem, user, userDataManager, logger, extractAudioLanguages, extractPeople, [], extractArtists);
+            return GetMediaType(libraryManager, baseItem, user, userDataManager, logger, extractAudioLanguages, extractPeople, []);
         }
         
         // Overload that supports extracting user data for multiple users
         public static Operand GetMediaType(ILibraryManager libraryManager, BaseItem baseItem, User user, 
             IUserDataManager userDataManager = null, ILogger logger = null, bool extractAudioLanguages = false, bool extractPeople = false, 
-            List<string> additionalUserIds = null, bool extractArtists = false)
+            List<string> additionalUserIds = null)
         {
             // Cache the IsPlayed result to avoid multiple expensive calls
             var isPlayed = baseItem.IsPlayed(user);
@@ -342,89 +342,87 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 }
             }
             
-            // Extract artists and album artists for music items - only when needed for performance
+            // Extract artists and album artists for music items (cheap operations, always extract)
             operand.Artists = [];
             operand.AlbumArtists = [];
-            if (extractArtists)
+            
+            try
             {
-                try
+                // Try to extract Artist property
+                var artistProperty = baseItem.GetType().GetProperty("Artist");
+                if (artistProperty != null)
                 {
-                    // Try to extract Artist property
-                    var artistProperty = baseItem.GetType().GetProperty("Artist");
-                    if (artistProperty != null)
+                    var artistValue = artistProperty.GetValue(baseItem) as string;
+                    if (!string.IsNullOrEmpty(artistValue))
                     {
-                        var artistValue = artistProperty.GetValue(baseItem) as string;
-                        if (!string.IsNullOrEmpty(artistValue))
-                        {
-                            operand.Artists.Add(artistValue);
-                        }
+                        operand.Artists.Add(artistValue);
                     }
-                    
-                    // Try to extract Artists property (collection)
-                    var artistsProperty = baseItem.GetType().GetProperty("Artists");
-                    if (artistsProperty != null)
+                }
+                
+                // Try to extract Artists property (collection)
+                var artistsProperty = baseItem.GetType().GetProperty("Artists");
+                if (artistsProperty != null)
+                {
+                    var artistsValue = artistsProperty.GetValue(baseItem);
+                    if (artistsValue is IEnumerable<string> artistsCollection)
                     {
-                        var artistsValue = artistsProperty.GetValue(baseItem);
-                        if (artistsValue is IEnumerable<string> artistsCollection)
+                        foreach (var artist in artistsCollection)
                         {
-                            foreach (var artist in artistsCollection)
+                            if (!string.IsNullOrEmpty(artist) && !operand.Artists.Contains(artist))
                             {
-                                if (!string.IsNullOrEmpty(artist) && !operand.Artists.Contains(artist))
-                                {
-                                    operand.Artists.Add(artist);
-                                }
+                                operand.Artists.Add(artist);
                             }
                         }
                     }
-                    
-                    // Try to extract AlbumArtist property
-                    var albumArtistProperty = baseItem.GetType().GetProperty("AlbumArtist");
-                    if (albumArtistProperty != null)
+                }
+                
+                // Try to extract AlbumArtist property
+                var albumArtistProperty = baseItem.GetType().GetProperty("AlbumArtist");
+                if (albumArtistProperty != null)
+                {
+                    var albumArtistValue = albumArtistProperty.GetValue(baseItem) as string;
+                    if (!string.IsNullOrEmpty(albumArtistValue))
                     {
-                        var albumArtistValue = albumArtistProperty.GetValue(baseItem) as string;
-                        if (!string.IsNullOrEmpty(albumArtistValue))
-                        {
-                            operand.AlbumArtists.Add(albumArtistValue);
-                        }
+                        operand.AlbumArtists.Add(albumArtistValue);
                     }
-                    
-                    // Try to extract AlbumArtists property (collection)
-                    var albumArtistsProperty = baseItem.GetType().GetProperty("AlbumArtists");
-                    if (albumArtistsProperty != null)
+                }
+                
+                // Try to extract AlbumArtists property (collection)
+                var albumArtistsProperty = baseItem.GetType().GetProperty("AlbumArtists");
+                if (albumArtistsProperty != null)
+                {
+                    var albumArtistsValue = albumArtistsProperty.GetValue(baseItem);
+                    if (albumArtistsValue is IEnumerable<string> albumArtistsCollection)
                     {
-                        var albumArtistsValue = albumArtistsProperty.GetValue(baseItem);
-                        if (albumArtistsValue is IEnumerable<string> albumArtistsCollection)
+                        foreach (var albumArtist in albumArtistsCollection)
                         {
-                            foreach (var albumArtist in albumArtistsCollection)
+                            if (!string.IsNullOrEmpty(albumArtist) && !operand.AlbumArtists.Contains(albumArtist))
                             {
-                                if (!string.IsNullOrEmpty(albumArtist) && !operand.AlbumArtists.Contains(albumArtist))
-                                {
-                                    operand.AlbumArtists.Add(albumArtist);
-                                }
+                                operand.AlbumArtists.Add(albumArtist);
                             }
                         }
                     }
+                }
+                
+                // Debug logging for discovered properties on Audio items
+                if (logger != null && baseItem.GetType().Name == "Audio")
+                {
+                    var properties = baseItem.GetType().GetProperties()
+                        .Where(p => p.Name.Contains("Artist", StringComparison.OrdinalIgnoreCase) || 
+                                  p.Name.Contains("Composer", StringComparison.OrdinalIgnoreCase) ||
+                                  p.Name.Contains("Performer", StringComparison.OrdinalIgnoreCase))
+                        .Select(p => p.Name).ToArray();
                     
-                    // Debug logging for discovered properties on Audio items
-                    if (logger != null && baseItem.GetType().Name == "Audio")
+                    if (properties.Length > 0)
                     {
-                        var properties = baseItem.GetType().GetProperties()
-                            .Where(p => p.Name.Contains("Artist", StringComparison.OrdinalIgnoreCase) || 
-                                      p.Name.Contains("Composer", StringComparison.OrdinalIgnoreCase) ||
-                                      p.Name.Contains("Performer", StringComparison.OrdinalIgnoreCase))
-                            .Select(p => p.Name).ToArray();
-                        
-                        if (properties.Length > 0)
-                        {
-                            logger.LogDebug("Available artist-related properties on Audio item '{Name}': [{Properties}]", 
-                                baseItem.Name, string.Join(", ", properties));
-                        }
+                        logger.LogDebug("Available artist-related properties on Audio item '{Name}': [{Properties}]", 
+                            baseItem.Name, string.Join(", ", properties));
                     }
                 }
-                catch (Exception ex)
-                {
-                    logger?.LogWarning(ex, "Failed to extract artists for item {Name}", baseItem.Name);
-                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to extract artists for item {Name}", baseItem.Name);
             }
             
             return operand;

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -403,22 +403,6 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                         }
                     }
                 }
-                
-                // Debug logging for discovered properties on Audio items
-                if (logger != null && baseItem.GetType().Name == "Audio")
-                {
-                    var properties = baseItem.GetType().GetProperties()
-                        .Where(p => p.Name.Contains("Artist", StringComparison.OrdinalIgnoreCase) || 
-                                  p.Name.Contains("Composer", StringComparison.OrdinalIgnoreCase) ||
-                                  p.Name.Contains("Performer", StringComparison.OrdinalIgnoreCase))
-                        .Select(p => p.Name).ToArray();
-                    
-                    if (properties.Length > 0)
-                    {
-                        logger.LogDebug("Available artist-related properties on Audio item '{Name}': [{Properties}]", 
-                            baseItem.Name, string.Join(", ", properties));
-                    }
-                }
             }
             catch (Exception ex)
             {

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,51 @@
+# Known Issues and Limitations
+
+## Playlist MediaType Issue
+
+### Description
+Jellyfin has a core limitation where all playlist XML files show `<PlaylistMediaType>Audio</PlaylistMediaType>` regardless of the actual content in the playlist. This affects smart playlists created by this plugin as well as manually created playlists.
+
+### Impact
+- **Most users**: No impact on functionality - video content plays correctly despite the incorrect XML
+- **Some users**: May experience playback issues where only audio plays instead of video
+- **Specific affected scenarios**: 
+  - Certain client applications that strictly validate playlist XML
+  - Some external playlist parsers
+  - VisionOS 2.0 and potentially other Apple platforms
+
+### Root Cause
+This is a Jellyfin server bug where:
+1. New playlists default to "Audio" MediaType when created empty
+2. Adding items to existing playlists doesn't update the MediaType property
+3. The MediaType property is read-only and cannot be modified by plugins
+4. Metadata refresh operations don't recalculate MediaType based on content
+
+### Current Status
+- **Plugin limitation**: This plugin cannot fix this issue as it requires changes to Jellyfin's core playlist handling
+- **Jellyfin issue**: This affects all playlists in Jellyfin, not just smart playlists
+- **Workaround**: None available at the plugin level. Editing the playlist XML file directly might help.
+
+### Verification
+You can verify this issue by:
+1. Creating any playlist (manual or smart) with video content
+2. Looking at the playlist XML file in your Jellyfin data directory
+3. Observing `<PlaylistMediaType>Audio</PlaylistMediaType>` even for video playlists
+
+### Recommendations
+If you experience playback issues:
+1. **Try different clients**: The issue may be client-specific
+2. **Use direct library browsing**: Instead of playlists, browse content directly
+3. **Report to Jellyfin**: Consider reporting this as a Jellyfin core issue
+4. **Manual playlist test**: Create a manual playlist with the same content to confirm the issue isn't plugin-specific
+
+### For Developers
+This issue has been thoroughly investigated:
+- MediaType property is read-only (`CanWrite: False`)
+- Reflection attempts to set MediaType fail
+- Metadata refresh operations don't fix the MediaType
+- The issue exists in Jellyfin's core `PlaylistManager.CreatePlaylist()` method
+
+### Related Information
+- **Bug first reported**: User feedback about VisionOS 2.0 playback issues
+- **Jellyfin versions affected**: All known versions
+- **Plugin versions affected**: All versions (not a plugin bug) 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The web interface provides access to all available fields for creating playlist 
 
 #### **Content Fields**
 - **Name** - Title of the media item
-- **Media Type** - The type of item (e.g., `Movie`, `Episode`, `Series`, `Audio`)
+- **Media Type** - The type of item (e.g., `Movie`, `Episode`, `Series`, `Music`)
 - **Audio Languages** - The audio language of the movie/TV show.
 - **Album** - Album name (for music)
 - **Folder Path** - Location in your library


### PR DESCRIPTION
- **Updated README**
- **Artists fields now work properly, closes https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/30**
- **- Added debug logs to check the MediaType of created Jellyfin playlists, noting that Jellyfin defaults to "Audio" for all playlists regardless of content. - Included comments in PlaylistService to highlight the MediaType limitation. - Removed unnecessary debug logging related to audio item properties in Factory.cs for cleaner code. - Added KNOWN_ISSUES.md with information about this playlist limitation.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a known issues document detailing a playlist media type limitation affecting playback on some platforms.
  * Updated the README to clarify example media types for playlists.
* **Bug Fixes**
  * Improved debug logging and comments regarding playlist media types to aid in troubleshooting.
* **Refactor**
  * Simplified and improved the logic for extracting artist information from media items.
  * Updated method signatures to remove unused parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->