### PR TITLE
You can now sort by Random
You can now choose an item limit when playlists are generated (defaults to 500 for new playlists and 0 (unlimited) for existing playlists).

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -13,6 +13,33 @@ The local development environment is completely contained within the `/dev` dire
 
 Use C# 12+ collection expressions for cleaner, more concise code.
 
+### UI Development Patterns
+
+When adding new form fields, implement across all flows: create form (defaults), edit form (backwards compatibility), display views, API handling, and backend DTOs.
+
+Implementation locations:
+- HTML: Add to create/edit sections
+- JavaScript: populateStaticSelects() for defaults, edit form loading, form submission, display functions
+- Backend: Update DTOs and validation
+
+Pattern:
+```javascript
+// Create defaults
+page.querySelector('#newField').value = config.DefaultNewField || 'default';
+
+// Edit with backwards compatibility  
+const fieldValue = playlist.NewField !== undefined ? playlist.NewField : 'default';
+page.querySelector('#newField').value = fieldValue;
+
+// Form submission
+const newFieldValue = page.querySelector('#newField').value;
+playlistDto.NewField = newFieldValue;
+
+// Display
+const displayValue = playlist.NewField || 'Default';
+html += '<strong>New Field:</strong> ' + displayValue + '<br>';
+```
+
 ### Metadata Extraction Patterns
 
 When adding new fields that require metadata from Jellyfin's BaseItem objects, follow these established patterns:

--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -651,6 +651,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                 OrderOptions = new[]
                 {
                     new { Value = "NoOrder", Label = "No Order" },
+                    new { Value = "Random", Label = "Random" },
                     new { Value = "Name Ascending", Label = "Name Ascending" },
                     new { Value = "Name Descending", Label = "Name Descending" },
                     new { Value = "ProductionYear Ascending", Label = "Production Year Ascending" },

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/PluginConfiguration.cs
@@ -18,5 +18,10 @@ namespace Jellyfin.Plugin.SmartPlaylist.Configuration
         /// Gets or sets whether new playlists should be public by default.
         /// </summary>
         public bool DefaultMakePublic { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the default maximum number of items for new playlists.
+        /// </summary>
+        public int DefaultMaxItems { get; set; } = 500;
     }
 } 

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -229,6 +229,7 @@
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="sortOrder">Sort Order</label>
                             <div id="sortOrder-container"></div>
+                            <div class="fieldDescription">Note: This field has no effect when "Random" is selected as Sort By.</div>
                         </div>
 
                         <div class="inputContainer" style="margin-bottom: 1.5em;">
@@ -237,6 +238,12 @@
                                 <option value="">Loading users...</option>
                             </select>
                             <div class="fieldDescription">The user who this playlist belongs to.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="playlistMaxItems">Max Items</label>
+                            <input type="number" is="emby-input" id="playlistMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <div class="fieldDescription">Maximum number of items in this playlist. Set to 0 for no limit.</div>
                         </div>
 
                         <div class="checkbox-container" style="margin-bottom: 1em; margin-top: 1em;">
@@ -307,6 +314,14 @@
                             </label>
                             <div class="fieldDescription">New smart playlists will be public by default when this is enabled.</div>
                         </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="defaultMaxItems">Default Max Items</label>
+                            <input type="number" is="emby-input" id="defaultMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <div class="fieldDescription">Default maximum number of items for new smart playlists. Set to 0 for no limit.</div>
+                        </div>
+
+
 
                         <div style="margin-top: 2em;">
                             <button type="button" is="emby-button" id="saveSettingsBtn" class="button-submit emby-button block">Save Settings</button>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -232,7 +232,7 @@
                             <div class="fieldDescription">Note: This field has no effect when "Random" is selected as Sort By.</div>
                         </div>
 
-                        <div class="inputContainer" style="margin-bottom: 1.5em;">
+                        <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel" for="playlistUser">Playlist Owner</label>
                             <select is="emby-select" id="playlistUser" class="emby-select" required>
                                 <option value="">Loading users...</option>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -449,12 +449,15 @@
             const defaultSortBy = config.DefaultSortBy || 'Name';
             const defaultSortOrder = config.DefaultSortOrder || 'Ascending';
             const defaultMakePublic = config.DefaultMakePublic || false;
-            const defaultMaxItems = config.DefaultMaxItems || 500;
+            const defaultMaxItems = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
             
             if (sortBySelect.children.length === 0) { populateSelect(sortBySelect, sortOptions, defaultSortBy); }
             if (sortOrderSelect.children.length === 0) { populateSelect(sortOrderSelect, orderOptions, defaultSortOrder); }
             page.querySelector('#playlistIsPublic').checked = defaultMakePublic;
-            page.querySelector('#playlistMaxItems').value = defaultMaxItems;
+            const maxItemsElement = page.querySelector('#playlistMaxItems');
+            if (maxItemsElement) {
+                maxItemsElement.value = defaultMaxItems;
+            }
             
             // Populate settings tab dropdowns with current configuration values
             const defaultSortBySetting = page.querySelector('#defaultSortBy');
@@ -1113,7 +1116,9 @@
             const orderName = sortByValue === 'Random' ? 'Random' : sortByValue + ' ' + sortOrderValue;
             const isPublic = page.querySelector('#playlistIsPublic').checked || false;
             const isEnabled = page.querySelector('#playlistIsEnabled').checked !== false; // Default to true if checkbox doesn't exist
-            const maxItems = parseInt(page.querySelector('#playlistMaxItems').value) || 500;
+            const maxItemsElement = page.querySelector('#playlistMaxItems');
+            const maxItemsInput = maxItemsElement?.value || '';
+            const maxItems = maxItemsInput === '' ? 500 : parseInt(maxItemsInput);
 
             // Get selected user ID from dropdown
             const userId = page.querySelector('#playlistUser').value;
@@ -1211,7 +1216,7 @@
             page.querySelector('#sortOrder').value = config.DefaultSortOrder || 'Ascending';
             page.querySelector('#playlistIsPublic').checked = config.DefaultMakePublic || false;
             page.querySelector('#playlistIsEnabled').checked = true; // Default to enabled
-            page.querySelector('#playlistMaxItems').value = config.DefaultMaxItems || 500;
+            page.querySelector('#playlistMaxItems').value = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
         }).catch(() => {
             page.querySelector('#sortBy').value = 'Name';
             page.querySelector('#sortOrder').value = 'Ascending';
@@ -2171,7 +2176,7 @@
             page.querySelector('#defaultSortBy').value = config.DefaultSortBy || 'Name';
             page.querySelector('#defaultSortOrder').value = config.DefaultSortOrder || 'Ascending';
             page.querySelector('#defaultMakePublic').checked = config.DefaultMakePublic || false;
-            page.querySelector('#defaultMaxItems').value = config.DefaultMaxItems || 500;
+            page.querySelector('#defaultMaxItems').value = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
             Dashboard.hideLoadingMsg();
         }).catch(() => {
             Dashboard.hideLoadingMsg();
@@ -2186,7 +2191,13 @@
             config.DefaultSortBy = page.querySelector('#defaultSortBy').value;
             config.DefaultSortOrder = page.querySelector('#defaultSortOrder').value;
             config.DefaultMakePublic = page.querySelector('#defaultMakePublic').checked;
-            config.DefaultMaxItems = parseInt(page.querySelector('#defaultMaxItems').value) || 500;
+            const defaultMaxItemsInput = page.querySelector('#defaultMaxItems').value;
+            if (defaultMaxItemsInput === '') {
+                config.DefaultMaxItems = 500;
+            } else {
+                const parsedValue = parseInt(defaultMaxItemsInput);
+                config.DefaultMaxItems = isNaN(parsedValue) ? 500 : parsedValue;
+            }
             apiClient.updatePluginConfiguration(getPluginId(), config).then(() => {
                 Dashboard.hideLoadingMsg();
                 showNotification('Settings saved.', 'success');

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -472,7 +472,10 @@
             if (sortBySelect.children.length === 0) { populateSelect(sortBySelect, sortOptions, 'Name'); }
             if (sortOrderSelect.children.length === 0) { populateSelect(sortOrderSelect, orderOptions, 'Ascending'); }
             page.querySelector('#playlistIsPublic').checked = false;
-            page.querySelector('#playlistMaxItems').value = 500;
+            const maxItemsElement = page.querySelector('#playlistMaxItems');
+            if (maxItemsElement) {
+                maxItemsElement.value = 500;
+            }
             
             // Populate settings tab dropdowns with defaults even if config fails
             const defaultSortBySetting = page.querySelector('#defaultSortBy');
@@ -1118,7 +1121,13 @@
             const isEnabled = page.querySelector('#playlistIsEnabled').checked !== false; // Default to true if checkbox doesn't exist
             const maxItemsElement = page.querySelector('#playlistMaxItems');
             const maxItemsInput = maxItemsElement?.value || '';
-            const maxItems = maxItemsInput === '' ? 500 : parseInt(maxItemsInput);
+            let maxItems;
+            if (maxItemsInput === '') {
+                maxItems = 500;
+            } else {
+                const parsedValue = parseInt(maxItemsInput);
+                maxItems = isNaN(parsedValue) ? 500 : parsedValue;
+            }
 
             // Get selected user ID from dropdown
             const userId = page.querySelector('#playlistUser').value;
@@ -1216,13 +1225,19 @@
             page.querySelector('#sortOrder').value = config.DefaultSortOrder || 'Ascending';
             page.querySelector('#playlistIsPublic').checked = config.DefaultMakePublic || false;
             page.querySelector('#playlistIsEnabled').checked = true; // Default to enabled
-            page.querySelector('#playlistMaxItems').value = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
+            const maxItemsElement = page.querySelector('#playlistMaxItems');
+            if (maxItemsElement) {
+                maxItemsElement.value = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
+            }
         }).catch(() => {
             page.querySelector('#sortBy').value = 'Name';
             page.querySelector('#sortOrder').value = 'Ascending';
             page.querySelector('#playlistIsPublic').checked = false;
             page.querySelector('#playlistIsEnabled').checked = true; // Default to enabled
-            page.querySelector('#playlistMaxItems').value = 500;
+            const maxItemsElement = page.querySelector('#playlistMaxItems');
+            if (maxItemsElement) {
+                maxItemsElement.value = 500;
+            }
         });
         
         // Create initial logic group with one rule

--- a/Jellyfin.Plugin.SmartPlaylist/Jellyfin.Plugin.SmartPlaylist.csproj
+++ b/Jellyfin.Plugin.SmartPlaylist/Jellyfin.Plugin.SmartPlaylist.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.10.*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.10.*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -981,9 +981,18 @@ namespace Jellyfin.Plugin.SmartPlaylist
         {
             if (items == null) return [];
             
+            // Convert to list to ensure stable enumeration
+            var itemsList = items.ToList();
+            if (itemsList.Count == 0) return [];
+            
             // Use current ticks as seed for different results each refresh
             var random = new Random((int)(DateTime.Now.Ticks & 0x7FFFFFFF));
-            return items.OrderBy(x => random.Next());
+            
+            // Create a list of items with their random keys to ensure consistent random values
+            var itemsWithKeys = itemsList.Select(item => new { Item = item, Key = random.Next() }).ToList();
+            
+            // Sort by the pre-generated random keys
+            return itemsWithKeys.OrderBy(x => x.Key).Select(x => x.Item);
         }
     }
 

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public Order Order { get; set; }
         public List<string> MediaTypes { get; set; }
         public List<ExpressionSet> ExpressionSets { get; set; }
+        public int MaxItems { get; set; }
 
         // OPTIMIZATION: Static cache for compiled rules to avoid recompilation
         private static readonly ConcurrentDictionary<string, List<List<Func<Operand, bool>>>> _ruleCache = new();
@@ -39,6 +40,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             UserId = dto.UserId;
             Order = OrderFactory.CreateOrder(dto.Order.Name);
             MediaTypes = dto.MediaTypes ?? [];
+            MaxItems = dto.MaxItems ?? 0; // Default to 0 (unlimited) for backwards compatibility
 
             if (dto.ExpressionSets != null && dto.ExpressionSets.Count > 0)
             {
@@ -544,14 +546,51 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 logger?.LogDebug("Playlist filtering for '{PlaylistName}' completed in {ElapsedTime}ms: {InputCount} items → {OutputCount} items", 
                     Name,stopwatch.ElapsedMilliseconds, totalItems, results.Count);
                 
-                // Apply ordering with error handling
+                // Apply ordering and max items limit with error handling
                 try
                 {
-                    return Order?.OrderBy(results).Select(x => x.Id) ?? results.Select(x => x.Id);
+                    var orderedResults = Order?.OrderBy(results) ?? results;
+                    
+                    // Apply max items logic with performance optimization
+                    if (MaxItems > 0)
+                    {
+                        if (Order is RandomOrder)
+                        {
+                            // For random order, we need to process all items first, then take max items
+                            // The RandomOrder.OrderBy already handles the randomization
+                            var limitedResults = orderedResults.Take(MaxItems);
+                            
+                            logger?.LogInformation("Applied random order and limited playlist '{PlaylistName}' to {MaxItems} items from {TotalItems} total items", 
+                                Name, MaxItems, orderedResults.Count());
+                            
+                            return limitedResults.Select(x => x.Id);
+                        }
+                        else
+                        {
+                            // Performance optimization: Take max items without randomization (deterministic order)
+                            var limitedResults = orderedResults.Take(MaxItems);
+                            
+                            logger?.LogInformation("Limited playlist '{PlaylistName}' to {MaxItems} items from {TotalItems} total items (deterministic order)", 
+                                Name, MaxItems, orderedResults.Count());
+                            
+                            return limitedResults.Select(x => x.Id);
+                        }
+                    }
+                    else
+                    {
+                        // No max items limit - return all ordered results
+                        if (Order is RandomOrder)
+                        {
+                            logger?.LogInformation("Applied random order to playlist '{PlaylistName}' with {TotalItems} items (no limit)", 
+                                Name, orderedResults.Count());
+                        }
+                        
+                        return orderedResults.Select(x => x.Id);
+                    }
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogError(ex, "Error applying ordering to playlist '{PlaylistName}'. Returning unordered results.", Name);
+                    logger?.LogError(ex, "Error applying ordering and max items to playlist '{PlaylistName}'. Returning unordered results.", Name);
                     return results.Select(x => x.Id);
                 }
             }
@@ -886,6 +925,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             { "ReleaseDate Descending", () => new ReleaseDateOrderDesc() },
             { "CommunityRating Ascending", () => new CommunityRatingOrder() },
             { "CommunityRating Descending", () => new CommunityRatingOrderDesc() },
+            { "Random", () => new RandomOrder() },
             { "NoOrder", () => new NoOrder() }
         };
 
@@ -931,6 +971,20 @@ namespace Jellyfin.Plugin.SmartPlaylist
     public class NoOrder : Order
     {
         public override string Name => "NoOrder";
+    }
+
+    public class RandomOrder : Order
+    {
+        public override string Name => "Random";
+
+        public override IEnumerable<BaseItem> OrderBy(IEnumerable<BaseItem> items)
+        {
+            if (items == null) return [];
+            
+            // Use current ticks as seed for different results each refresh
+            var random = new Random((int)(DateTime.Now.Ticks & 0x7FFFFFFF));
+            return items.OrderBy(x => random.Next());
+        }
     }
 
     public class ProductionYearOrder : Order

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
@@ -24,6 +24,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public bool Public { get; set; } = false; // Default to private
         public List<string> MediaTypes { get; set; } = []; // Pre-filter media types
         public bool Enabled { get; set; } = true; // Default to enabled
+        public int? MaxItems { get; set; } // Nullable to support backwards compatibility
         
         // Legacy support - for migration from old User field
         [Obsolete("Use UserId instead. This property is for backward compatibility only.")]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A rebuilt and modernized plugin to create smart, rule-based playlists in Jellyfi
 
 This plugin allows you to create dynamic playlists based on a set of rules, which will automatically update as your library changes. 
 
-Tested and works with Jellyfin version `10.10.0` and newer.
+Requires Jellyfin version `10.10.0` and newer.
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ This plugin creates smart playlists that automatically updates based on rules yo
 
 The plugin features a modern web-based interface for easy playlist management - no technical knowledge required.
 
+### Enhanced Music Tagging
+
+For even more powerful music playlist creation, combine this plugin with the **[MusicTags plugin](https://github.com/jyourstone/jellyfin-musictags-plugin)**. The MusicTags plugin extracts custom tags from your audio files (like "BPM", "Mood", "Key", etc.) and makes them available as tags in Jellyfin. You can then use these extracted tags in SmartPlaylist rules to create dynamic playlists based on the actual content of your music files.
+
+For example, create playlists for:
+- **Running playlist** (tracks with BPM 140-160 AND genre "Dance")
+- **Favorite relaxing music** (tracks with mood "Chill" AND marked as favorite)
+
 ## How to Install
 
 ### From Repository

--- a/example.playlist.json
+++ b/example.playlist.json
@@ -31,5 +31,6 @@
   "MediaTypes": [
     "Movie"
   ],
-  "Enabled": true
+  "Enabled": true,
+  "MaxItems": 500
 }


### PR DESCRIPTION
- **Now works with Jellyfin 10.10.x (which was intended from the beginning). Fixes https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/32**
- **Updated README to suggest combining this plugin with the MusicTags plugin.**
- **Added two new features based on the suggestions in https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/33: - You can now sort by "Random" - You can now choose an item limit when playlists are generated (defaults to 500 for new playlists and 0 (unlimited) for existing playlists).**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Random" sort option for playlists, allowing items to be ordered randomly.
  * Introduced a configurable "Max Items" setting to limit the number of items in a playlist, with support for both per-playlist and default values.
  * Playlist creation and editing forms now include fields for setting the maximum number of items.

* **Enhancements**
  * UI updates to display and configure the new "Random" sort and "Max Items" options.
  * Added explanatory notes in the UI regarding the behavior of the new options.

* **Documentation**
  * Expanded documentation with guidelines for consistent UI development and integration of new form fields.
  * Updated README to clarify Jellyfin version requirements and added recommendations for enhanced music tagging.

* **Chores**
  * Updated example playlist configuration to demonstrate the new "MaxItems" property.
  * Pinned dependency versions for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->