### PR TITLE
Connect playlists by ID and update existing playlist on name and owner changes

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -67,7 +67,7 @@ logger?.LogDebug("Methods containing 'keyword': [{Methods}]", string.Join(", ", 
 ## Debugging Workflow
 1. Make code changes
 2. Build: `./build-local.sh` from `/dev`
-3. Wait for container restart (10-15 seconds)
+3. Wait for user input
 4. Check logs: `tail -n 100 jellyfin-data/config/log/log_YYYYMMDD.log`
 
 Log analysis:

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,28 +1,22 @@
 ---
-description: 
-globs: 
 alwaysApply: true
 ---
-### Development Environment
 
-The local development environment is completely contained within the `/dev` directory.
+## Development Environment
+Local development is contained in `/dev` directory. Use `./build-local.sh` from `/dev` for builds. Don't modify files outside `/dev` for local testing.
 
-- This includes the `docker-compose.yml`, the `build-local.sh` script, test media folders, and the `jellyfin-data` directory. The build script is configured to use a separate `meta-dev.json` file and handles all necessary paths for a local build. Do not modify files outside of `/dev` for local testing.
+## Code Patterns
+Use C# 12+ collection expressions for cleaner code.
 
-### C# 12+ Collection Expressions
+## UI Development
+When adding form fields, implement across all flows: create form (defaults), edit form (backwards compatibility), display views, API handling, backend DTOs.
 
-Use C# 12+ collection expressions for cleaner, more concise code.
-
-### UI Development Patterns
-
-When adding new form fields, implement across all flows: create form (defaults), edit form (backwards compatibility), display views, API handling, and backend DTOs.
-
-Implementation locations:
+Implementation pattern:
 - HTML: Add to create/edit sections
-- JavaScript: populateStaticSelects() for defaults, edit form loading, form submission, display functions
+- JavaScript: populateStaticSelects() for defaults, edit form loading, form submission, display functions  
 - Backend: Update DTOs and validation
 
-Pattern:
+JavaScript pattern:
 ```javascript
 // Create defaults
 page.querySelector('#newField').value = config.DefaultNewField || 'default';
@@ -40,13 +34,10 @@ const displayValue = playlist.NewField || 'Default';
 html += '<strong>New Field:</strong> ' + displayValue + '<br>';
 ```
 
-### Metadata Extraction Patterns
+## Metadata Extraction Patterns
 
-When adding new fields that require metadata from Jellyfin's BaseItem objects, follow these established patterns:
-
-#### Direct Property Access (Cheap Operations)
+### Direct Property Access (Cheap Operations)
 ```csharp
-// These work directly and are performant
 operand.Genres = baseItem.Genres.ToList();
 operand.Studios = baseItem.Studios.ToList();
 operand.Tags = baseItem.Tags?.ToList() ?? new List<string>();
@@ -54,22 +45,18 @@ operand.Name = baseItem.Name;
 operand.ProductionYear = baseItem.ProductionYear.GetValueOrDefault();
 ```
 
-#### Library Manager Queries (Expensive Operations)
+### Library Manager Queries (Expensive Operations)
 ```csharp
-// Use for related data that requires database queries
 var peopleQuery = new InternalPeopleQuery { ItemId = baseItem.Id };
 var getPeopleMethod = libraryManager.GetType().GetMethod("GetPeople", new[] { typeof(InternalPeopleQuery) });
 var result = getPeopleMethod.Invoke(libraryManager, new object[] { peopleQuery });
 ```
 
-#### Reflection-Based Discovery
-When exploring unknown object structures, use this debugging pattern:
+### Reflection-Based Discovery
 ```csharp
-// Discover available properties
 var properties = someObject.GetType().GetProperties().Select(p => p.Name).ToArray();
 logger?.LogDebug("Available properties: [{Properties}]", string.Join(", ", properties));
 
-// Discover available methods
 var methods = someObject.GetType().GetMethods()
     .Where(m => m.Name.Contains("keyword"))
     .Select(m => m.Name)
@@ -77,38 +64,28 @@ var methods = someObject.GetType().GetMethods()
 logger?.LogDebug("Methods containing 'keyword': [{Methods}]", string.Join(", ", methods));
 ```
 
-### Debugging and Testing Workflow
+## Debugging Workflow
+1. Make code changes
+2. Build: `./build-local.sh` from `/dev`
+3. Wait for container restart (10-15 seconds)
+4. Check logs: `tail -n 100 jellyfin-data/config/log/log_YYYYMMDD.log`
 
-#### Local Development Loop
-1. **Make code changes**
-2. **Build**: `./build-local.sh` (from `/dev` directory)
-3. **Wait for container restart** (10-15 seconds)
-4. **Check logs**: `tail -n 100 jellyfin-data/config/log/log_YYYYMMDD.log`
-
-#### Log Analysis Patterns
+Log analysis:
 ```bash
-# Find specific debug messages
 grep -A 10 -B 5 "specific_debug_message" jellyfin-data/config/log/log_*.log
-
-# Monitor real-time logs during testing
 tail -f jellyfin-data/config/log/log_*.log | grep "SmartPlaylist"
-
-# Count log entries for performance analysis
 grep -c "expensive_operation" jellyfin-data/config/log/log_*.log
 ```
 
-#### Debugging Unknown Data Structures
-Always add comprehensive logging when exploring new object types:
+Debugging unknown data structures:
 ```csharp
 if (result != null)
 {
     logger?.LogDebug("Result type: {Type}", result.GetType().Name);
     
-    // Log properties
     var properties = result.GetType().GetProperties().Select(p => p.Name).ToArray();
     logger?.LogDebug("Properties: [{Props}]", string.Join(", ", properties));
     
-    // Test if it's enumerable
     if (result is IEnumerable<object> enumerable)
     {
         var items = enumerable.Take(3).ToList();
@@ -123,69 +100,176 @@ if (result != null)
 }
 ```
 
-### Performance Optimization Architecture
+Always check README.md when adding or changing features and update it to reflect the changes if needed.
 
-The plugin implements a two-phase filtering approach for expensive fields (AudioLanguages, People):
+## Performance Optimization
+Two-phase filtering for expensive fields (AudioLanguages, People):
+1. Phase 1 (Cheap): Extract basic properties, evaluate non-expensive rules
+2. Phase 2 (Expensive): Only for items passing Phase 1, extract expensive data, evaluate complete rules
 
-1. **Phase 1 (Cheap)**: Extract basic properties and evaluate non-expensive rules
-2. **Phase 2 (Expensive)**: Only for items that pass Phase 1, extract expensive data and evaluate complete rules
+Adding new expensive fields:
+1. Add property to Operand class as `List<string>` or appropriate type
+2. Modify Factory.cs with extraction logic in expensive field parameter
+3. Update SmartPlaylist.cs filtering with field detection and expensive field condition
+4. Add to API in appropriate field category in SmartPlaylistController.cs
+5. Update UI in config.html if collection field
 
-#### Adding New Expensive Fields
+## Jellyfin Data Patterns
 
-1. **Add to Operand class**: Add the new property as `List<string>` or appropriate type
-2. **Modify Factory.cs**:
-   ```csharp
-   public static Operand GetMediaType(..., bool extractExpensiveField = false)
-   {
-       operand.ExpensiveField = new List<string>();
-       if (extractExpensiveField)
-       {
-           try
-           {
-               // Expensive extraction logic here
-           }
-           catch (Exception ex)
-           {
-               logger?.LogWarning(ex, "Error extracting expensive field");
-           }
-       }
-   }
-   ```
+### BaseItem Properties (Direct Access)
+- Name, ProductionYear, OfficialRating
+- Genres, Studios, Tags (collections)
+- CommunityRating, CriticRating (may need .GetValueOrDefault())
+- DateCreated, DateModified, DateLastRefreshed
+- IsPlayed(user) (user-specific)
 
-3. **Update SmartPlaylist.cs filtering**:
-   ```csharp
-   // Add field detection
-   var needsExpensiveField = ExpressionSets
-       .SelectMany(set => set.Expressions)
-       .Any(expr => expr.MemberName == "ExpensiveField");
-   
-   // Add to expensive field condition
-   if (needsAudioLanguages || needsPeople || needsExpensiveField)
-   {
-       // Add to expensive rule categorization and method calls
-       OperandFactory.GetMediaType(..., needsAudioLanguages, needsPeople, needsExpensiveField);
-   }
-   ```
+### Requires Library Manager Queries
+- People/Cast/Crew: Use InternalPeopleQuery with ItemId
+- Audio/Subtitle streams: Access via MediaSources property or GetMediaStreams() method
+- Related items: Use appropriate query objects
 
-4. **Add to API**: Include in the appropriate field category in `SmartPlaylistController.cs`
-5. **Update UI**: Add to list fields in `config.html` if it's a collection
+### User Data (Requires UserDataManager)
+- PlayCount, IsFavorite, LastPlayedDate
 
-### Common Jellyfin Data Patterns
+## Music Fields
+Artists (track-level) and AlbumArtists (album-level) are separate from People field (movies/TV only). These are cheap operations (simple property access via reflection), not expensive like People (database queries) or AudioLanguages (media stream analysis). NOT included in expensive field optimization logic.
 
-#### BaseItem Properties (Usually Direct Access)
-- `Name`, `ProductionYear`, `OfficialRating`
-- `Genres`, `Studios`, `Tags` (collections)
-- `CommunityRating`, `CriticRating` (may need `.GetValueOrDefault()`)
-- `DateCreated`, `DateModified`, `DateLastRefreshed`
-- `IsPlayed(user)` (user-specific)
 
-#### Requires Library Manager Queries
-- **People/Cast/Crew**: Use `InternalPeopleQuery` with `ItemId`
-- **Audio/Subtitle streams**: Access via `MediaSources` property or `GetMediaStreams()` method
-- **Related items**: Use appropriate query objects
+### Music Fields
 
-#### User Data (Requires UserDataManager)
-- `PlayCount`, `IsFavorite`, `LastPlayedDate`
+**Artists** (track-level) and **AlbumArtists** (album-level) are separate from **People** field (movies/TV only). These are **cheap operations** (simple property access via reflection), not expensive like People (database queries) or AudioLanguages (media stream analysis). They are NOT included in expensive field optimization logic.
+## Development Environment
+Local development is contained in `/dev` directory. Use `./build-local.sh` from `/dev` for builds. Don't modify files outside `/dev` for local testing.
+
+## Code Patterns
+Use C# 12+ collection expressions for cleaner code.
+
+## UI Development
+When adding form fields, implement across all flows: create form (defaults), edit form (backwards compatibility), display views, API handling, backend DTOs.
+
+Implementation pattern:
+- HTML: Add to create/edit sections
+- JavaScript: populateStaticSelects() for defaults, edit form loading, form submission, display functions  
+- Backend: Update DTOs and validation
+
+JavaScript pattern:
+```javascript
+// Create defaults
+page.querySelector('#newField').value = config.DefaultNewField || 'default';
+
+// Edit with backwards compatibility  
+const fieldValue = playlist.NewField !== undefined ? playlist.NewField : 'default';
+page.querySelector('#newField').value = fieldValue;
+
+// Form submission
+const newFieldValue = page.querySelector('#newField').value;
+playlistDto.NewField = newFieldValue;
+
+// Display
+const displayValue = playlist.NewField || 'Default';
+html += '<strong>New Field:</strong> ' + displayValue + '<br>';
+```
+
+## Metadata Extraction Patterns
+
+### Direct Property Access (Cheap Operations)
+```csharp
+operand.Genres = baseItem.Genres.ToList();
+operand.Studios = baseItem.Studios.ToList();
+operand.Tags = baseItem.Tags?.ToList() ?? new List<string>();
+operand.Name = baseItem.Name;
+operand.ProductionYear = baseItem.ProductionYear.GetValueOrDefault();
+```
+
+### Library Manager Queries (Expensive Operations)
+```csharp
+var peopleQuery = new InternalPeopleQuery { ItemId = baseItem.Id };
+var getPeopleMethod = libraryManager.GetType().GetMethod("GetPeople", new[] { typeof(InternalPeopleQuery) });
+var result = getPeopleMethod.Invoke(libraryManager, new object[] { peopleQuery });
+```
+
+### Reflection-Based Discovery
+```csharp
+var properties = someObject.GetType().GetProperties().Select(p => p.Name).ToArray();
+logger?.LogDebug("Available properties: [{Properties}]", string.Join(", ", properties));
+
+var methods = someObject.GetType().GetMethods()
+    .Where(m => m.Name.Contains("keyword"))
+    .Select(m => m.Name)
+    .ToArray();
+logger?.LogDebug("Methods containing 'keyword': [{Methods}]", string.Join(", ", methods));
+```
+
+## Debugging Workflow
+1. Make code changes
+2. Build: `./build-local.sh` from `/dev`
+3. Wait for container restart (10-15 seconds)
+4. Check logs: `tail -n 100 jellyfin-data/config/log/log_YYYYMMDD.log`
+
+Log analysis:
+```bash
+grep -A 10 -B 5 "specific_debug_message" jellyfin-data/config/log/log_*.log
+tail -f jellyfin-data/config/log/log_*.log | grep "SmartPlaylist"
+grep -c "expensive_operation" jellyfin-data/config/log/log_*.log
+```
+
+Debugging unknown data structures:
+```csharp
+if (result != null)
+{
+    logger?.LogDebug("Result type: {Type}", result.GetType().Name);
+    
+    var properties = result.GetType().GetProperties().Select(p => p.Name).ToArray();
+    logger?.LogDebug("Properties: [{Props}]", string.Join(", ", properties));
+    
+    if (result is IEnumerable<object> enumerable)
+    {
+        var items = enumerable.Take(3).ToList();
+        logger?.LogDebug("Enumerable with {Count} items (showing first 3)", items.Count);
+        
+        foreach (var item in items)
+        {
+            var itemProps = item.GetType().GetProperties().Select(p => p.Name).ToArray();
+            logger?.LogDebug("Item properties: [{Props}]", string.Join(", ", itemProps));
+        }
+    }
+}
+```
+
+Always check README.md when adding or changing features.
+
+## Performance Optimization
+Two-phase filtering for expensive fields (AudioLanguages, People):
+1. Phase 1 (Cheap): Extract basic properties, evaluate non-expensive rules
+2. Phase 2 (Expensive): Only for items passing Phase 1, extract expensive data, evaluate complete rules
+
+Adding new expensive fields:
+1. Add property to Operand class as `List<string>` or appropriate type
+2. Modify Factory.cs with extraction logic in expensive field parameter
+3. Update SmartPlaylist.cs filtering with field detection and expensive field condition
+4. Add to API in appropriate field category in SmartPlaylistController.cs
+5. Update UI in config.html if collection field
+
+## Jellyfin Data Patterns
+
+### BaseItem Properties (Direct Access)
+- Name, ProductionYear, OfficialRating
+- Genres, Studios, Tags (collections)
+- CommunityRating, CriticRating (may need .GetValueOrDefault())
+- DateCreated, DateModified, DateLastRefreshed
+- IsPlayed(user) (user-specific)
+
+### Requires Library Manager Queries
+- People/Cast/Crew: Use InternalPeopleQuery with ItemId
+- Audio/Subtitle streams: Access via MediaSources property or GetMediaStreams() method
+- Related items: Use appropriate query objects
+
+### User Data (Requires UserDataManager)
+- PlayCount, IsFavorite, LastPlayedDate
+
+## Music Fields
+Artists (track-level) and AlbumArtists (album-level) are separate from People field (movies/TV only). These are cheap operations (simple property access via reflection), not expensive like People (database queries) or AudioLanguages (media stream analysis). NOT included in expensive field optimization logic.
+
 
 ### Music Fields
 

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
@@ -16,6 +16,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
     public class SmartPlaylistDto
     {
         public string Id { get; set; }
+        public string JellyfinPlaylistId { get; set; }  // Jellyfin playlist ID for reliable lookup
         public string Name { get; set; }
         public string FileName { get; set; }
         public Guid UserId { get; set; }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The web interface is organized into three tabs:
 1.  **Create Playlist**: This is where you build new playlists.
     -   Define the rules for including items.
     -   Choose the sort order.
+    -   Set the maximum number of items (defaults to 500).
     -   Select which user should own the playlist.
     -   Decide if the playlist should be public or private.
     -   Choose whether or not to enable the playlist.
@@ -192,11 +193,23 @@ The plugin uses **.NET regex syntax** (not JavaScript, Perl, or other flavors):
 ### Sorting Options
 
 - **No Order** - Items appear in library order
-- **Release Date**
-- **Production Year**
-- **Community Rating**
+- **Name** - Sort by title
+- **Release Date** - Sort by release date
+- **Production Year** - Sort by production year
+- **Community Rating** - Sort by user ratings
+- **Date Created** - Sort by when added to library
+- **Random** - Randomize the order of items
 - **Ascending** - Oldest first
 - **Descending** - Newest first
+
+### Max Items
+
+You can optionally set a maximum number of items for your smart playlist. This is useful for:
+- Limiting large playlists to a manageable size
+- Creating "Top 10" or "Best of" style playlists
+- Improving performance for very large libraries
+
+**Note**: Setting this to unlimited (0) might cause performance issues or even crashes for very large playlists.
 
 ### Rule Logic
 


### PR DESCRIPTION
- **Updated README and Cursor rules**
- **Changing the name or owner of a smart playlist now updates the existing playlist instead of recreating it. This means for example that playlist images you add manually will stay intact.**
- **Connect smart playlists to Jellyfin playlists by ID primarily, instead of name.**
