### PR TITLE
Jellyfin playlist ID is now stored in the json file when the refresh task is running as well.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/ScheduleTasks/RefreshAllPlaylists.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/ScheduleTasks/RefreshAllPlaylists.cs
@@ -340,6 +340,15 @@ namespace Jellyfin.Plugin.SmartPlaylist.ScheduleTasks
                                         
                                         // Refresh metadata to generate cover images
                                         await RefreshPlaylistMetadataAsync(existingPlaylist, cancellationToken).ConfigureAwait(false);
+                                        
+                                        // Save the Jellyfin playlist ID if it's not already saved
+                                        if (string.IsNullOrEmpty(dto.JellyfinPlaylistId) || dto.JellyfinPlaylistId != existingPlaylist.Id.ToString())
+                                        {
+                                            dto.JellyfinPlaylistId = existingPlaylist.Id.ToString();
+                                            await plStore.SaveAsync(dto);
+                                            logger.LogDebug("Saved Jellyfin playlist ID {JellyfinPlaylistId} for smart playlist {PlaylistName}", 
+                                                existingPlaylist.Id, dto.Name);
+                                        }
                                     }
                                 }
                                                                     else
@@ -367,6 +376,12 @@ namespace Jellyfin.Plugin.SmartPlaylist.ScheduleTasks
                                         
                                         // Refresh metadata to generate cover images
                                         await RefreshPlaylistMetadataAsync(newPlaylist, cancellationToken).ConfigureAwait(false);
+                                        
+                                        // Save the Jellyfin playlist ID for the newly created playlist
+                                        dto.JellyfinPlaylistId = newPlaylist.Id.ToString();
+                                        await plStore.SaveAsync(dto);
+                                        logger.LogDebug("Saved Jellyfin playlist ID {JellyfinPlaylistId} for newly created smart playlist {PlaylistName}", 
+                                            newPlaylist.Id, dto.Name);
                                     }
                                 }
                                 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ Here are some of the planned features for future updates. Feel free to contribut
 
 - **More Rule Fields**: Add additional fields if needed, [request here](https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues).
 - **Auto refresh**: Make smart playlists update automatically on library changes instead of a fixed schedule.
-- **Caching**: Look into a cache solution to increase performance.
-- **Connect playlist ID**: Connect smart playlists to Jellyfin playlists by ID instead of name. Would also include updating existing playlists instead of recreating.
 
 ## Development
 


### PR DESCRIPTION
- **Updated README**
- **Jellyfin playlist ID is now stored in the json file when the refresh task is running as well.**
