### PR TITLE
Split playlist refresh task into separate audio and video tasks. Fixed config page error.

### DIFF
--- a/.cursor/rules/html.mdc
+++ b/.cursor/rules/html.mdc
@@ -37,7 +37,7 @@ Jellyfin's custom element system has timing issues when `is="emby-input"` is use
 
 #### The Solution
 
-**Always use ONLY `class="emby-input"` for styling input elements:**
+**Do NOT use `is="emby-input"` for styling input elements:**
 
 ```html
 <!-- ✅ CORRECT - Works perfectly -->
@@ -48,25 +48,3 @@ Jellyfin's custom element system has timing issues when `is="emby-input"` is use
 <input type="text" is="emby-input" id="myInput" class="emby-input">
 <input type="number" is="emby-input" id="myNumber" class="emby-input">
 ```
-
-#### Checkbox Label Rules
-
-When checkboxes are **nested inside labels**, do NOT use `for` attributes:
-
-```html
-<!-- ✅ CORRECT - Automatic association through nesting -->
-<label class="checkboxLabel">
-    <input type="checkbox" is="emby-checkbox" id="myCheckbox" class="emby-checkbox">
-    <span>Label Text</span>
-</label>
-
-<!-- ❌ WRONG - Causes htmlFor conflicts -->
-<label class="checkboxLabel" for="myCheckbox">
-    <input type="checkbox" is="emby-checkbox" id="myCheckbox" class="emby-checkbox">
-    <span>Label Text</span>
-</label>
-```
-
-#### Root Cause
-
-The `is="emby-input"` attribute triggers Jellyfin's custom element upgrade process, which tries to set `htmlFor` properties on elements that may not be ready for association during initialization. Using only `class="emby-input"` provides the same styling without the custom element timing issues.

--- a/.cursor/rules/html.mdc
+++ b/.cursor/rules/html.mdc
@@ -22,3 +22,51 @@ When handling API errors, remember that the server returns error messages in a s
 To maintain a consistent and professional appearance, all UI elements must use Jellyfin's standard CSS classes.
 
 - Avoid using custom inline styles for layout and component styling. Instead, use Jellyfin's predefined classes like `inputContainer`, `inputLabel` `sectionTitle`, `checkboxLabel`, `fieldDescription`, `emby-button`, and `raised` to ensure the plugin's UI matches the native Jellyfin look and feel.
+
+### 4. Jellyfin Custom Element System - CRITICAL
+
+**NEVER use `is="emby-input"` on input elements.** This is a critical issue that causes `Cannot set properties of undefined (setting 'htmlFor')` errors and breaks the entire page initialization.
+
+#### The Problem
+
+Jellyfin's custom element system has timing issues when `is="emby-input"` is used on input elements during page initialization. This causes:
+- Console errors: `Cannot set properties of undefined (setting 'htmlFor')`
+- Checkboxes failing to display on initial page load
+- Custom element upgrade failures
+- Complete page functionality breakdown
+
+#### The Solution
+
+**Always use ONLY `class="emby-input"` for styling input elements:**
+
+```html
+<!-- ✅ CORRECT - Works perfectly -->
+<input type="text" id="myInput" class="emby-input">
+<input type="number" id="myNumber" class="emby-input">
+
+<!-- ❌ WRONG - Causes htmlFor errors -->
+<input type="text" is="emby-input" id="myInput" class="emby-input">
+<input type="number" is="emby-input" id="myNumber" class="emby-input">
+```
+
+#### Checkbox Label Rules
+
+When checkboxes are **nested inside labels**, do NOT use `for` attributes:
+
+```html
+<!-- ✅ CORRECT - Automatic association through nesting -->
+<label class="checkboxLabel">
+    <input type="checkbox" is="emby-checkbox" id="myCheckbox" class="emby-checkbox">
+    <span>Label Text</span>
+</label>
+
+<!-- ❌ WRONG - Causes htmlFor conflicts -->
+<label class="checkboxLabel" for="myCheckbox">
+    <input type="checkbox" is="emby-checkbox" id="myCheckbox" class="emby-checkbox">
+    <span>Label Text</span>
+</label>
+```
+
+#### Root Cause
+
+The `is="emby-input"` attribute triggers Jellyfin's custom element upgrade process, which tries to set `htmlFor` properties on elements that may not be ready for association during initialization. Using only `class="emby-input"` provides the same styling without the custom element timing issues.

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -195,19 +195,19 @@
                         <div class="inputContainer" style="margin-bottom: 1em;">
                             <label class="inputLabel">Media Types</label>
                             <div class="media-type-flex">
-                                <label class="checkboxLabel">
+                                <label class="checkboxLabel" for="mediaTypeMovie">
                                     <input type="checkbox" is="emby-checkbox" id="mediaTypeMovie" class="emby-checkbox media-type-checkbox" value="Movie">
                                     <span>Movies</span>
                                 </label>
-                                <label class="checkboxLabel">
+                                <label class="checkboxLabel" for="mediaTypeSeries">
                                     <input type="checkbox" is="emby-checkbox" id="mediaTypeSeries" class="emby-checkbox media-type-checkbox" value="Series">
                                     <span>Series</span>
                                 </label>
-                                <label class="checkboxLabel">
+                                <label class="checkboxLabel" for="mediaTypeEpisode">
                                     <input type="checkbox" is="emby-checkbox" id="mediaTypeEpisode" class="emby-checkbox media-type-checkbox" value="Episode">
                                     <span>Episodes</span>
                                 </label>
-                                <label class="checkboxLabel">
+                                <label class="checkboxLabel" for="mediaTypeAudio">
                                     <input type="checkbox" is="emby-checkbox" id="mediaTypeAudio" class="emby-checkbox media-type-checkbox" value="Audio">
                                     <span>Music</span>
                                 </label>
@@ -247,7 +247,7 @@
                         </div>
 
                         <div class="checkbox-container" style="margin-bottom: 1em; margin-top: 1em;">
-                            <label class="checkboxLabel">
+                            <label class="checkboxLabel" for="playlistIsPublic">
                                 <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" class="emby-checkbox">
                                 <span>Make playlist public</span>
                             </label>
@@ -255,7 +255,7 @@
                         </div>
 
                         <div class="checkbox-container" style="margin-bottom: 1em; margin-top: 1em;">
-                            <label class="checkboxLabel">
+                            <label class="checkboxLabel" for="playlistIsEnabled">
                                 <input type="checkbox" is="emby-checkbox" id="playlistIsEnabled" class="emby-checkbox" checked>
                                 <span>Enable playlist</span>
                             </label>
@@ -308,7 +308,7 @@
                         </div>
 
                         <div class="checkbox-container" style="margin-bottom: 1em; margin-top: 1em;">
-                            <label class="checkboxLabel">
+                            <label class="checkboxLabel" for="defaultMakePublic">
                                 <input type="checkbox" is="emby-checkbox" id="defaultMakePublic" class="emby-checkbox">
                                 <span>Make playlists public by default</span>
                             </label>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -242,7 +242,7 @@
 
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="playlistMaxItems">Max Items</label>
-                            <input type="number" is="emby-input" id="playlistMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <input type="number" id="playlistMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
                             <div class="fieldDescription">Maximum number of items in this playlist. Set to 0 for no limit.</div>
                         </div>
 
@@ -317,20 +317,21 @@
 
                         <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="inputLabel" for="defaultMaxItems">Default Max Items</label>
-                            <input type="number" is="emby-input" id="defaultMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <input type="number" id="defaultMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
                             <div class="fieldDescription">Default maximum number of items for new smart playlists. Set to 0 for no limit.</div>
                         </div>
 
                         <h3 class="sectionTitle" style="margin-top: 2em;">Playlist Naming</h3>
+                        
                         <div class="input-group" style="display: flex; gap: 2em;">
                             <div class="inputContainer flex-grow">
                                 <label class="inputLabel" for="playlistNamePrefix">Prefix Text</label>
-                                <input type="text" is="emby-input" id="playlistNamePrefix" class="emby-input">
+                                <input type="text" id="playlistNamePrefix" class="emby-input">
                                 <div class="fieldDescription">Text to add before the playlist name. Leave blank for no prefix.</div>
                             </div>
                             <div class="inputContainer flex-grow">
                                 <label class="inputLabel" for="playlistNameSuffix">Suffix Text</label>
-                                <input type="text" is="emby-input" id="playlistNameSuffix" class="emby-input">
+                                <input type="text" id="playlistNameSuffix" class="emby-input">
                                 <div class="fieldDescription">Text to add after the playlist name. Leave blank for no suffix.</div>
                             </div>
                         </div>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -1852,7 +1852,7 @@
         
         apiClient.ajax({
             type: 'POST',
-            url: apiClient.getUrl('Plugins/SmartPlaylist/' + playlistId + '/refresh'),
+            url: apiClient.getUrl(ENDPOINTS.base + '/' + playlistId + '/refresh'),
             contentType: 'application/json'
         }).then(() => {
             Dashboard.hideLoadingMsg();

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -1561,6 +1561,7 @@
                         '</div>' +
                         '<div style="margin-top: 1em;">' +
                         '<button type="button" is="emby-button" class="emby-button raised edit-playlist-btn" data-playlist-id="' + playlistId + '" style="margin-right: 0.5em;">Edit</button>' +
+                        '<button type="button" is="emby-button" class="emby-button raised refresh-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Refresh</button>' +
                         (isEnabled ? 
                             '<button type="button" is="emby-button" class="emby-button raised disable-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Disable</button>' :
                             '<button type="button" is="emby-button" class="emby-button raised enable-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Enable</button>'
@@ -1832,6 +1833,7 @@
                 '</div>' +
                 '<div style="margin-top: 1em;">' +
                 '<button type="button" is="emby-button" class="emby-button raised edit-playlist-btn" data-playlist-id="' + playlistId + '" style="margin-right: 0.5em;">Edit</button>' +
+                '<button type="button" is="emby-button" class="emby-button raised refresh-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Refresh</button>' +
                 (isEnabled ? 
                     '<button type="button" is="emby-button" class="emby-button raised disable-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Disable</button>' :
                     '<button type="button" is="emby-button" class="emby-button raised enable-playlist-btn" data-playlist-id="' + playlistId + '" data-playlist-name="' + playlist.Name + '" style="margin-right: 0.5em;">Enable</button>'
@@ -1841,6 +1843,25 @@
                 '</div>';
         }
         container.innerHTML = html;
+    }
+
+    function refreshPlaylist(page, playlistId, playlistName) {
+        const apiClient = getApiClient();
+        
+        Dashboard.showLoadingMsg();
+        
+        apiClient.ajax({
+            type: 'POST',
+            url: apiClient.getUrl('Plugins/SmartPlaylist/' + playlistId + '/refresh'),
+            contentType: 'application/json'
+        }).then(() => {
+            Dashboard.hideLoadingMsg();
+            showNotification('Playlist "' + playlistName + '" has been refreshed successfully.', 'success');
+        }).catch((err) => {
+            Dashboard.hideLoadingMsg();
+            console.error('Error refreshing playlist:', err);
+            handleApiError(err, 'Failed to refresh playlist');
+        });
     }
 
     function deletePlaylist(page, playlistId, playlistName) {
@@ -2222,6 +2243,7 @@
         getApiClient().getPluginConfiguration(getPluginId()).then(config => {
             page.querySelector('#defaultSortBy').value = config.DefaultSortBy || 'Name';
             page.querySelector('#defaultSortOrder').value = config.DefaultSortOrder || 'Ascending';
+            
             page.querySelector('#defaultMakePublic').checked = config.DefaultMakePublic || false;
             page.querySelector('#defaultMaxItems').value = config.DefaultMaxItems !== undefined && config.DefaultMaxItems !== null ? config.DefaultMaxItems : 500;
             
@@ -2274,7 +2296,7 @@
             contentType: 'application/json'
         }).then(() => {
             Dashboard.hideLoadingMsg();
-            showNotification('Smart playlist refresh task has been triggered. Playlists will be updated shortly.', 'success');
+            showNotification('SmartPlaylist refresh tasks have been triggered. All smart playlists will be updated shortly.', 'success');
         }).catch((err) => {
             Dashboard.hideLoadingMsg();
             console.error('Error refreshing playlists:', err);
@@ -2322,6 +2344,8 @@
         `;
         document.head.appendChild(style);
     }
+
+
 
     function initPage(page) {
         // Check if this specific page is already initialized
@@ -2562,6 +2586,10 @@
             if (target.closest('.edit-playlist-btn')) {
                 const button = target.closest('.edit-playlist-btn');
                 editPlaylist(page, button.getAttribute('data-playlist-id'));
+            }
+            if (target.closest('.refresh-playlist-btn')) {
+                const button = target.closest('.refresh-playlist-btn');
+                refreshPlaylist(page, button.getAttribute('data-playlist-id'), button.getAttribute('data-playlist-name'));
             }
             if (target.closest('.enable-playlist-btn')) {
                 const button = target.closest('.enable-playlist-btn');

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
@@ -68,7 +68,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 new TaskTriggerInfo
                 {
                     Type = TaskTriggerInfo.TriggerDaily,
-                    TimeOfDayTicks = TimeSpan.FromHours(2.5).Ticks // 2:30 AM
+                    TimeOfDayTicks = TimeSpan.FromHours(3.5).Ticks // 3:30 AM
                 }
             ];
         }

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartPlaylist
+{
+    /// <summary>
+    /// Scheduled task for refreshing audio/music smart playlists.
+    /// </summary>
+    public class RefreshAudioPlaylistsTask : RefreshPlaylistsTaskBase
+    {
+        public RefreshAudioPlaylistsTask(
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            ILogger<RefreshAudioPlaylistsTask> logger,
+            IServerApplicationPaths serverApplicationPaths,
+            IPlaylistManager playlistManager,
+            IUserDataManager userDataManager,
+            IProviderManager providerManager)
+            : base(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
+        {
+        }
+
+        public override string Name => "Refresh Audio SmartPlaylists";
+        public override string Description => "Refresh all audio/music SmartPlaylists";
+        public override string Key => "RefreshAudioSmartPlaylists";
+
+        protected override string GetHandledMediaTypes()
+        {
+            return "audio";
+        }
+
+        protected override IEnumerable<SmartPlaylistDto> FilterPlaylistsByMediaType(IEnumerable<SmartPlaylistDto> playlists)
+        {
+            return playlists.Where(playlist => 
+                playlist.MediaTypes != null && 
+                playlist.MediaTypes.Any(mediaType => mediaType == "Audio"));
+        }
+
+        protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
+        {
+            var query = new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Audio],
+                Recursive = true
+            };
+
+            return libraryManager.GetItemsResult(query).Items;
+        }
+
+        /// <summary>
+        /// Gets the default triggers - runs once daily at 2:30 AM.
+        /// </summary>
+        /// <returns>IEnumerable{TaskTriggerInfo}.</returns>
+        public override IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return
+            [
+                new TaskTriggerInfo
+                {
+                    Type = TaskTriggerInfo.TriggerDaily,
+                    TimeOfDayTicks = TimeSpan.FromHours(2.5).Ticks // 2:30 AM
+                }
+            ];
+        }
+    }
+} 

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Controller.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SmartPlaylist
+{
+    /// <summary>
+    /// Scheduled task for refreshing video smart playlists (movies, series, episodes).
+    /// </summary>
+    public class RefreshVideoPlaylistsTask : RefreshPlaylistsTaskBase
+    {
+        public RefreshVideoPlaylistsTask(
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            ILogger<RefreshVideoPlaylistsTask> logger,
+            IServerApplicationPaths serverApplicationPaths,
+            IPlaylistManager playlistManager,
+            IUserDataManager userDataManager,
+            IProviderManager providerManager)
+            : base(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
+        {
+        }
+
+        public override string Name => "Refresh Video SmartPlaylists";
+        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes)";
+        public override string Key => "RefreshVideoSmartPlaylists";
+
+        protected override string GetHandledMediaTypes()
+        {
+            return "video";
+        }
+
+        protected override IEnumerable<SmartPlaylistDto> FilterPlaylistsByMediaType(IEnumerable<SmartPlaylistDto> playlists)
+        {
+            return playlists.Where(playlist => 
+                playlist.MediaTypes != null && 
+                playlist.MediaTypes.Any(mediaType => 
+                    mediaType == "Movie" || 
+                    mediaType == "Series" || 
+                    mediaType == "Episode"));
+        }
+
+        protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
+        {
+            var query = new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series],
+                Recursive = true
+            };
+
+            return libraryManager.GetItemsResult(query).Items;
+        }
+    }
+} 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requires Jellyfin version `10.10.0` and newer.
 - [📦 How to Install](#-how-to-install)
 - [🚀 Roadmap](#-roadmap)
 - [🛠️ Development](#️-development)
-- [🔧 Advanced Configuration](#️-advanced-configuration)
+- [🔧 Advanced Configuration](#-advanced-configuration)
 - [🙏 Credits](#-credits)
 - [⚠️ Disclaimer](#️-disclaimer)
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ The naming configuration applies to all new smart playlists. When you delete a s
 Smart playlists automatically refresh using scheduled tasks:
 
 #### **Scheduled Tasks**
-- **🎵 Audio SmartPlaylists**: Runs by default daily at **2:30 AM**
+- **🎵 Audio SmartPlaylists**: Runs by default daily at **3:30 AM**
 - **🎬 Video SmartPlaylists**: Runs by default **hourly**
+
+These tasks can be configured in the Jellyfin admin dashboard.
 
 #### **Manual Refresh**
 - Use the **"Refresh All Playlists"** button in the Settings tab to trigger both tasks immediately

--- a/README.md
+++ b/README.md
@@ -16,22 +16,12 @@ Requires Jellyfin version `10.10.0` and newer.
 
 - [✨ Features](#-features)
 - [⚙️ Configuration](#️-configuration)
-  - [Using the Web Interface](#using-the-web-interface)
-  - [Flexible Deletion Options](#flexible-deletion-options)
-  - [Custom Playlist Naming](#custom-playlist-naming)
-  - [Automatic Updates](#automatic-updates)
 - [📋 Overview](#-overview)
-- [Enhanced Music Tagging](#enhanced-music-tagging)
+- [🎵 Enhanced Music Tagging](#enhanced-music-tagging)
 - [📦 How to Install](#-how-to-install)
 - [🚀 Roadmap](#-roadmap)
 - [🛠️ Development](#️-development)
 - [🔧 Advanced Configuration](#️-advanced-configuration)
-  - [Available Fields](#available-fields)
-  - [Available Operators](#available-operators)
-  - [Sorting Options](#sorting-options)
-  - [Max Items](#max-items)
-  - [Rule Logic](#rule-logic)
-  - [Manual Configuration](#manual-configuration-advanced-users)
 - [🙏 Credits](#-credits)
 - [⚠️ Disclaimer](#️-disclaimer)
 
@@ -118,7 +108,7 @@ This plugin creates smart playlists that automatically updates based on rules yo
 
 The plugin features a modern web-based interface for easy playlist management - no technical knowledge required.
 
-### Enhanced Music Tagging
+### 🎵 Enhanced Music Tagging
 
 For even more powerful music playlist creation, combine this plugin with the **[MusicTags plugin](https://github.com/jyourstone/jellyfin-musictags-plugin)**. The MusicTags plugin extracts custom tags from your audio files (like "BPM", "Mood", "Key", etc.) and makes them available as tags in Jellyfin. You can then use these extracted tags in SmartPlaylist rules to create dynamic playlists based on the actual content of your music files.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Requires Jellyfin version `10.10.0` and newer.
 - [✨ Features](#-features)
 - [⚙️ Configuration](#️-configuration)
 - [📋 Overview](#-overview)
-- [🎵 Enhanced Music Tagging](#enhanced-music-tagging)
 - [📦 How to Install](#-how-to-install)
 - [🚀 Roadmap](#-roadmap)
 - [🛠️ Development](#️-development)
@@ -108,7 +107,7 @@ This plugin creates smart playlists that automatically updates based on rules yo
 
 The plugin features a modern web-based interface for easy playlist management - no technical knowledge required.
 
-### 🎵 Enhanced Music Tagging
+### Enhanced Music Tagging
 
 For even more powerful music playlist creation, combine this plugin with the **[MusicTags plugin](https://github.com/jyourstone/jellyfin-musictags-plugin)**. The MusicTags plugin extracts custom tags from your audio files (like "BPM", "Mood", "Key", etc.) and makes them available as tags in Jellyfin. You can then use these extracted tags in SmartPlaylist rules to create dynamic playlists based on the actual content of your music files.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Requires Jellyfin version `10.10.0` and newer.
 - ✏️ **Edit Playlists** - Modify existing smart playlists directly from the UI.
 - 👥 **User Selection** - Choose which user should own a playlist with an intuitive dropdown, making it easy to create playlists for different family members.
 - 🎯 **Flexible Rules** - Build simple or complex rules with an intuitive builder. 
-- 🔄 **Automatic Updates** - Playlists refresh automatically (scheduled task).
+- 🔄 **Automatic Updates** - Playlists refresh automatically (scheduled tasks).
 - ⚙️ **Settings** - Configure default settings and trigger a manual refresh for all playlists at any time.
 - 🛠️ **Advanced Options** - Support for regex patterns, date ranges, and more.
 - 🎵 **All Media Types** - Works with movies, series, episodes, and music
@@ -90,9 +90,16 @@ The naming configuration applies to all new smart playlists. When you delete a s
 
 ### Automatic Updates
 
-Smart playlists automatically refresh when:
-- The "Refresh all SmartPlaylists" scheduled task runs
-- You manually trigger the task from the Jellyfin dashboard
+Smart playlists automatically refresh using scheduled tasks:
+
+#### **Scheduled Tasks**
+- **🎵 Audio SmartPlaylists**: Runs by default daily at **2:30 AM**
+- **🎬 Video SmartPlaylists**: Runs by default **hourly**
+
+#### **Manual Refresh**
+- Use the **"Refresh All Playlists"** button in the Settings tab to trigger both tasks immediately
+- Use the **"Refresh"** button next to each playlist in the Manage Playlists tab to refresh individual playlists
+- Individual tasks can also be triggered separately from the Jellyfin admin dashboard
 
 ## 📋 Overview
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ This plugin allows you to create dynamic playlists based on a set of rules, whic
 
 Requires Jellyfin version `10.10.0` and newer.
 
+## 📋 Table of Contents
+
+- [✨ Features](#-features)
+- [⚙️ Configuration](#️-configuration)
+  - [Using the Web Interface](#using-the-web-interface)
+  - [Flexible Deletion Options](#flexible-deletion-options)
+  - [Custom Playlist Naming](#custom-playlist-naming)
+  - [Automatic Updates](#automatic-updates)
+- [📋 Overview](#-overview)
+- [Enhanced Music Tagging](#enhanced-music-tagging)
+- [📦 How to Install](#-how-to-install)
+- [🚀 Roadmap](#-roadmap)
+- [🛠️ Development](#️-development)
+- [🔧 Advanced Configuration](#️-advanced-configuration)
+  - [Available Fields](#available-fields)
+  - [Available Operators](#available-operators)
+  - [Sorting Options](#sorting-options)
+  - [Max Items](#max-items)
+  - [Rule Logic](#rule-logic)
+  - [Manual Configuration](#manual-configuration-advanced-users)
+- [🙏 Credits](#-credits)
+- [⚠️ Disclaimer](#️-disclaimer)
+
 ## ✨ Features
 
 - 🚀 **Modern Jellyfin Support** - Built for newer Jellyfin versions with improved compatibility.

--- a/example.playlist.json
+++ b/example.playlist.json
@@ -1,5 +1,6 @@
 {
   "Id": "df62a8cc-c65c-4f47-9d8b-9b0a7ce9b337",
+  "JellyfinPlaylistId": "6af9cf0e9b656e168e33f68d73856adf",
   "Name": "90s Action Movies",
   "FileName": "90s_Action_Movies.json",
   "UserId": "e8be2e45-65a8-4529-a416-a14d1bf6b7d1",


### PR DESCRIPTION
- **Added table of contents**
- **Updated README**
- **Updated README**
- **Updated README**
- **Split playlist refresh task into two, one for videos and one for audio. Added refresh button for individual playlists in the Manage Playlist tab. Minor config page changes.**
- **Fixed config page issue which caused console errors and styling errors. Updated example playlist to include Jellyfin Playlist ID.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate scheduled tasks for refreshing audio and video smart playlists with configurable schedules.
  * Introduced a "Refresh" button in the playlist management UI to manually refresh individual smart playlists.
  * Added a new API endpoint to trigger a refresh for a specific playlist by its ID.

* **Improvements**
  * Enhanced documentation and UI guidelines for HTML plugin development, clarifying correct usage of custom elements and label associations.
  * Updated the README with a detailed table of contents and clearer instructions for automatic and manual playlist refresh options.

* **Bug Fixes**
  * Improved error handling and log messages for playlist refresh operations.
  * Fixed issues related to input and label associations in the configuration UI.

* **Documentation**
  * Provided clearer examples and explanations for correct HTML markup in plugin UIs.
  * Updated the example playlist JSON with a new identifier field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->