### PR TITLE
You can now You can now set a max playtime in minutes for playlists

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/PluginConfiguration.cs
@@ -25,6 +25,11 @@ namespace Jellyfin.Plugin.SmartPlaylist.Configuration
         public int DefaultMaxItems { get; set; } = 500;
 
         /// <summary>
+        /// Gets or sets the default maximum play time in minutes for new playlists.
+        /// </summary>
+        public int DefaultMaxPlayTimeMinutes { get; set; } = 0;
+
+        /// <summary>
         /// Gets or sets the prefix text to add to playlist names.
         /// Leave empty to not add a prefix.
         /// </summary>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -246,6 +246,12 @@
                             <div class="fieldDescription">Maximum number of items in this playlist. Set to 0 for no limit.</div>
                         </div>
 
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="playlistMaxPlayTimeMinutes">Max Play Time (Minutes)</label>
+                            <input type="number" id="playlistMaxPlayTimeMinutes" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <div class="fieldDescription">Maximum play time in minutes for this playlist. Set to 0 for no limit.</div>
+                        </div>
+
                         <div class="checkbox-container" style="margin-bottom: 1em; margin-top: 1em;">
                             <label class="checkboxLabel" for="playlistIsPublic">
                                 <input type="checkbox" is="emby-checkbox" id="playlistIsPublic" class="emby-checkbox">
@@ -319,6 +325,12 @@
                             <label class="inputLabel" for="defaultMaxItems">Default Max Items</label>
                             <input type="number" id="defaultMaxItems" class="emby-input" min="0" step="1" style="max-width: 200px;">
                             <div class="fieldDescription">Default maximum number of items for new smart playlists. Set to 0 for no limit.</div>
+                        </div>
+
+                        <div class="inputContainer" style="margin-bottom: 1em; margin-top: 1em;">
+                            <label class="inputLabel" for="defaultMaxPlayTimeMinutes">Default Max Play Time (Minutes)</label>
+                            <input type="number" id="defaultMaxPlayTimeMinutes" class="emby-input" min="0" step="1" style="max-width: 200px;">
+                            <div class="fieldDescription">Default maximum play time in minutes for new smart playlists. Set to 0 for no limit.</div>
                         </div>
 
                         <h3 class="sectionTitle" style="margin-top: 2em;">Playlist Naming</h3>

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -4,7 +4,6 @@ using MediaBrowser.Controller.Library;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Data.Entities;
-using System.Linq;
 
 namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
 {
@@ -43,8 +42,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 Album = baseItem.Album,
                 ProductionYear = baseItem.ProductionYear.GetValueOrDefault(),
                 Tags = baseItem.Tags is not null ? [.. baseItem.Tags] : [],
-                RuntimeMinutes = baseItem.RunTimeTicks.HasValue ?
-                    (int)TimeSpan.FromTicks(baseItem.RunTimeTicks.Value).TotalMinutes : 0,
+                RuntimeMinutes = baseItem.RunTimeTicks.HasValue ? TimeSpan.FromTicks(baseItem.RunTimeTicks.Value).TotalMinutes : 0.0,
                 // Initialize user data properties with fallback values
                 PlayCount = isPlayed ? 1 : 0,
                 IsFavorite = false

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public double DateModified { get; set; } = 0;
         public double ReleaseDate { get; set; } = 0;
         public List<string> Tags { get; set; } = [];
-        public int RuntimeMinutes { get; set; } = 0;
+        public double RuntimeMinutes { get; set; } = 0;
         public int PlayCount { get; set; } = 0;
         public string OfficialRating { get; set; } = "";
         public bool IsFavorite { get; set; } = false;

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
@@ -16,20 +16,15 @@ namespace Jellyfin.Plugin.SmartPlaylist
     /// <summary>
     /// Scheduled task for refreshing audio/music smart playlists.
     /// </summary>
-    public class RefreshAudioPlaylistsTask : RefreshPlaylistsTaskBase
+    public class RefreshAudioPlaylistsTask(
+        IUserManager userManager,
+        ILibraryManager libraryManager,
+        ILogger<RefreshAudioPlaylistsTask> logger,
+        IServerApplicationPaths serverApplicationPaths,
+        IPlaylistManager playlistManager,
+        IUserDataManager userDataManager,
+        IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public RefreshAudioPlaylistsTask(
-            IUserManager userManager,
-            ILibraryManager libraryManager,
-            ILogger<RefreshAudioPlaylistsTask> logger,
-            IServerApplicationPaths serverApplicationPaths,
-            IPlaylistManager playlistManager,
-            IUserDataManager userDataManager,
-            IProviderManager providerManager)
-            : base(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
-        {
-        }
-
         public override string Name => "Refresh Audio SmartPlaylists";
         public override string Description => "Refresh all audio/music SmartPlaylists";
         public override string Key => "RefreshAudioSmartPlaylists";

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Data.Enums;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
@@ -19,36 +18,25 @@ namespace Jellyfin.Plugin.SmartPlaylist
     /// <summary>
     /// Abstract base class for playlist refresh tasks.
     /// </summary>
-    public abstract class RefreshPlaylistsTaskBase : IScheduledTask
+    public abstract class RefreshPlaylistsTaskBase(
+        IUserManager userManager,
+        ILibraryManager libraryManager,
+        ILogger logger,
+        IServerApplicationPaths serverApplicationPaths,
+        IPlaylistManager playlistManager,
+        IUserDataManager userDataManager,
+        IProviderManager providerManager) : IScheduledTask
     {
-        protected readonly IUserManager userManager;
-        protected readonly ILibraryManager libraryManager;
-        protected readonly ILogger logger;
-        protected readonly IServerApplicationPaths serverApplicationPaths;
-        protected readonly IPlaylistManager playlistManager;
-        protected readonly IUserDataManager userDataManager;
-        protected readonly IProviderManager providerManager;
+        protected readonly IUserManager userManager = userManager;
+        protected readonly ILibraryManager libraryManager = libraryManager;
+        protected readonly ILogger logger = logger;
+        protected readonly IServerApplicationPaths serverApplicationPaths = serverApplicationPaths;
+        protected readonly IPlaylistManager playlistManager = playlistManager;
+        protected readonly IUserDataManager userDataManager = userDataManager;
+        protected readonly IProviderManager providerManager = providerManager;
 
         // Simple semaphore to prevent concurrent migration saves (rare but can cause file corruption)
         private static readonly SemaphoreSlim _migrationSemaphore = new(1, 1);
-
-        protected RefreshPlaylistsTaskBase(
-            IUserManager userManager,
-            ILibraryManager libraryManager,
-            ILogger logger,
-            IServerApplicationPaths serverApplicationPaths,
-            IPlaylistManager playlistManager,
-            IUserDataManager userDataManager,
-            IProviderManager providerManager)
-        {
-            this.userManager = userManager;
-            this.libraryManager = libraryManager;
-            this.logger = logger;
-            this.serverApplicationPaths = serverApplicationPaths;
-            this.playlistManager = playlistManager;
-            this.userDataManager = userDataManager;
-            this.providerManager = providerManager;
-        }
 
         private PlaylistService GetPlaylistService()
         {

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
@@ -14,20 +14,15 @@ namespace Jellyfin.Plugin.SmartPlaylist
     /// <summary>
     /// Scheduled task for refreshing video smart playlists (movies, series, episodes).
     /// </summary>
-    public class RefreshVideoPlaylistsTask : RefreshPlaylistsTaskBase
+    public class RefreshVideoPlaylistsTask(
+        IUserManager userManager,
+        ILibraryManager libraryManager,
+        ILogger<RefreshVideoPlaylistsTask> logger,
+        IServerApplicationPaths serverApplicationPaths,
+        IPlaylistManager playlistManager,
+        IUserDataManager userDataManager,
+        IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public RefreshVideoPlaylistsTask(
-            IUserManager userManager,
-            ILibraryManager libraryManager,
-            ILogger<RefreshVideoPlaylistsTask> logger,
-            IServerApplicationPaths serverApplicationPaths,
-            IPlaylistManager playlistManager,
-            IUserDataManager userDataManager,
-            IProviderManager providerManager)
-            : base(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
-        {
-        }
-
         public override string Name => "Refresh Video SmartPlaylists";
         public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes)";
         public override string Key => "RefreshVideoSmartPlaylists";

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
@@ -26,6 +26,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public List<string> MediaTypes { get; set; } = []; // Pre-filter media types
         public bool Enabled { get; set; } = true; // Default to enabled
         public int? MaxItems { get; set; } // Nullable to support backwards compatibility
+        public int? MaxPlayTimeMinutes { get; set; } // Nullable to support backwards compatibility
         
         // Legacy support - for migration from old User field
         [Obsolete("Use UserId instead. This property is for backward compatibility only.")]

--- a/README.md
+++ b/README.md
@@ -235,12 +235,23 @@ The plugin uses **.NET regex syntax** (not JavaScript, Perl, or other flavors):
 
 ### Max Items
 
-You can optionally set a maximum number of items for your smart playlist. This is useful for:
+You can optionally set a maximum number of items for your smart playlist. This is for example useful for:
 - Limiting large playlists to a manageable size
 - Creating "Top 10" or "Best of" style playlists
 - Improving performance for very large libraries
 
 **Note**: Setting this to unlimited (0) might cause performance issues or even crashes for very large playlists.
+
+### Max Play Time
+
+You can optionally set a maximum play time in minutes for your smart playlist. This is for example useful for:
+- Creating workout playlists that match your exercise duration
+- Setting up Pomodoro-style work sessions with music
+- Ensuring playlists fit within specific time constraints
+
+**How it works**: The plugin calculates the total runtime of items in the playlist and stops adding items when the time limit is reached. The last item that would exceed the limit is not included, ensuring the playlist stays within your specified duration.
+
+**Note**: This feature works with all media types (movies, TV shows, music) and uses the actual runtime of each item. For music, this means the exact duration of each track.
 
 ### Rule Logic
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set a maximum total play time (in minutes) for smart playlists, both as a default setting and per playlist.
  * Updated the configuration interface to support specifying and displaying maximum play time limits.
  * Playlists now stop adding items once the total play time or item count limit is reached.

* **Documentation**
  * Updated the README with a new section explaining the maximum play time feature and its use cases.

* **Refactor**
  * Improved code structure for scheduled playlist refresh tasks without changing user-facing functionality.

* **Style**
  * Enhanced display of playlist limits in the user interface for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->