### PR TITLE
Pre-filter media types through API instead of own logic

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -296,7 +296,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     return (false, "No user found for playlist", string.Empty);
                 }
 
-                var allUserMedia = GetAllUserMedia(user).ToArray();
+                var allUserMedia = GetAllUserMedia(user, dto.MediaTypes).ToArray();
                 
                 var (success, message, jellyfinPlaylistId) = await ProcessPlaylistRefreshAsync(dto, user, allUserMedia, _logger, null, cancellationToken);
                 
@@ -741,15 +741,60 @@ namespace Jellyfin.Plugin.SmartPlaylist
 
             return null;
         }
-        private IEnumerable<BaseItem> GetAllUserMedia(User user)
+        private IEnumerable<BaseItem> GetAllUserMedia(User user, List<string> mediaTypes = null)
         {
             var query = new InternalItemsQuery(user)
             {
-                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series],
+                IncludeItemTypes = GetBaseItemKindsFromMediaTypes(mediaTypes),
                 Recursive = true
             };
 
             return _libraryManager.GetItemsResult(query).Items;
+        }
+
+        /// <summary>
+        /// Maps string media types to BaseItemKind enums for API-level filtering
+        /// </summary>
+        private BaseItemKind[] GetBaseItemKindsFromMediaTypes(List<string> mediaTypes)
+        {
+            // If no media types specified, return all supported types (backward compatibility)
+            if (mediaTypes == null || mediaTypes.Count == 0)
+            {
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series];
+            }
+
+            var baseItemKinds = new List<BaseItemKind>();
+            
+            foreach (var mediaType in mediaTypes)
+            {
+                switch (mediaType)
+                {
+                    case "Movie":
+                        baseItemKinds.Add(BaseItemKind.Movie);
+                        break;
+                    case "Audio":
+                        baseItemKinds.Add(BaseItemKind.Audio);
+                        break;
+                    case "Episode":
+                        baseItemKinds.Add(BaseItemKind.Episode);
+                        break;
+                    case "Series":
+                        baseItemKinds.Add(BaseItemKind.Series);
+                        break;
+                    default:
+                        _logger?.LogWarning("Unknown media type '{MediaType}' - skipping", mediaType);
+                        break;
+                }
+            }
+
+            // Fallback to all types if no valid media types were found
+            if (baseItemKinds.Count == 0)
+            {
+                _logger?.LogWarning("No valid media types found, falling back to all supported types");
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series];
+            }
+
+            return [.. baseItemKinds];
         }
 
         private async Task RefreshPlaylistMetadataAsync(Playlist playlist, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -381,27 +381,9 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     return [];
                 }
                 
-                // Apply media type pre-filtering first for performance
-                if (MediaTypes != null && MediaTypes.Count > 0)
-                {
-                    try
-                    {
-                        var originalCount = itemCount;
-                        items = items.Where(item => item != null && MediaTypes.Contains(item.GetType().Name));
-                        var filteredCount = items.Count();
-                        logger?.LogDebug("Media type pre-filtering reduced items from {OriginalCount} to {FilteredCount} (filtering for: {MediaTypes})", 
-                            originalCount, filteredCount, string.Join(", ", MediaTypes));
-                    }
-                    catch (Exception ex)
-                    {
-                        logger?.LogWarning(ex, "Error during media type pre-filtering for playlist '{PlaylistName}'. Continuing without pre-filtering.", Name);
-                        // Continue without pre-filtering
-                    }
-                }
-                else
-                {
-                    logger?.LogDebug("No media type pre-filtering applied (no MediaTypes specified)");
-                }
+                // Media type filtering is now handled at the API level in PlaylistService.GetAllUserMedia()
+                // This provides significant performance improvements by filtering at the database level
+                logger?.LogDebug("Processing {ItemCount} items (already filtered by media type at API level)", itemCount);
                 
                 var results = new List<BaseItem>();
 


### PR DESCRIPTION
## Summary by Sourcery

Pre-filter playlist items by media type at the API level by passing media types to the internal query instead of filtering in-memory

Enhancements:
- Add mediaTypes parameter to GetAllUserMedia and apply IncludeItemTypes in the InternalItemsQuery for API-level filtering
- Introduce GetBaseItemKindsFromMediaTypes helper to map user-provided media type strings to BaseItemKind enums with fallback to all types and logging on invalid entries
- Remove manual LINQ-based media type filtering in SmartPlaylist.FilterPlaylistItems and replace it with a log message acknowledging API-level pre-filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playlists can now be filtered by specific media types (such as Movie, Audio, Episode, Series) during refresh, allowing for more precise playlist content.

* **Performance Improvements**
  * Media type filtering is now performed earlier in the process, improving efficiency when refreshing playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->