### PR TITLE
Added new field 'Last Played'

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -642,7 +642,10 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     new { Value = "Name", Label = "Name" },
                     new { Value = "OfficialRating", Label = "Parental Rating" },
                     new { Value = "Overview", Label = "Overview" },
-                    new { Value = "ProductionYear", Label = "Production Year" }
+                    new { Value = "ProductionYear", Label = "Production Year" },
+                    new { Value = "ReleaseDate", Label = "Release Date" }
+                    // Note: ItemType (Media Type) is intentionally excluded from UI fields
+                    // because users select media type (Audio/Video) before creating rules
                 },
                 RatingsPlaybackFields = new[]
                 {
@@ -650,15 +653,23 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     new { Value = "CriticRating", Label = "Critic Rating" },
                     new { Value = "IsFavorite", Label = "Is Favorite" },
                     new { Value = "IsPlayed", Label = "Is Played" },
+                    new { Value = "LastPlayedDate", Label = "Last Played" },
                     new { Value = "NextUnwatched", Label = "Next Unwatched" },
                     new { Value = "PlayCount", Label = "Play Count" },
                     new { Value = "RuntimeMinutes", Label = "Runtime (Minutes)" }
                 },
-                DateFields = FieldDefinitions.DateFields.Select(field => new { Value = field, Label = GetFieldLabel(field) }).ToArray(),
+
                 FileFields = new[]
                 {
                     new { Value = "FileName", Label = "File Name" },
-                    new { Value = "FolderPath", Label = "Folder Path" }
+                    new { Value = "FolderPath", Label = "Folder Path" },
+                    new { Value = "DateModified", Label = "Date Modified" }
+                },
+                LibraryFields = new[]
+                {
+                    new { Value = "DateCreated", Label = "Date Added to Library" },
+                    new { Value = "DateLastRefreshed", Label = "Last Metadata Refresh" },
+                    new { Value = "DateLastSaved", Label = "Last Database Save" }
                 },
                 CollectionFields = new[]
                 {

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -14,10 +14,10 @@
     const FIELD_TYPES = {
         LIST_FIELDS: ['People', 'Genres', 'Studios', 'Tags', 'Artists', 'AlbumArtists'],
         NUMERIC_FIELDS: ['ProductionYear', 'CommunityRating', 'CriticRating', 'RuntimeMinutes', 'PlayCount'],
-        DATE_FIELDS: ['DateCreated', 'DateLastRefreshed', 'DateLastSaved', 'DateModified', 'ReleaseDate'],
+        DATE_FIELDS: ['DateCreated', 'DateLastRefreshed', 'DateLastSaved', 'DateModified', 'ReleaseDate', 'LastPlayedDate'],
         BOOLEAN_FIELDS: ['IsPlayed', 'IsFavorite', 'NextUnwatched'],
         SIMPLE_FIELDS: ['ItemType'],
-        USER_DATA_FIELDS: ['IsPlayed', 'IsFavorite', 'PlayCount', 'NextUnwatched']
+        USER_DATA_FIELDS: ['IsPlayed', 'IsFavorite', 'PlayCount', 'NextUnwatched', 'LastPlayedDate']
     };
     
     // Centralized styling configuration
@@ -380,7 +380,7 @@
         const groupConfig = [
             { key: 'ContentFields', label: 'Content' },
             { key: 'RatingsPlaybackFields', label: 'Ratings & Playback' },
-            { key: 'DateFields', label: 'Dates' },
+            { key: 'LibraryFields', label: 'Library' },
             { key: 'FileFields', label: 'File Info' },
             { key: 'CollectionFields', label: 'Collections' }
         ];

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
@@ -34,6 +34,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 "PlayCount" => "GetPlayCountByUser", 
                 "IsFavorite" => "GetIsFavoriteByUser",
                 "NextUnwatched" => "GetNextUnwatchedByUser",
+                "LastPlayedDate" => "GetLastPlayedDateByUser",
                 _ => MemberName
             };
         }
@@ -46,6 +47,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 "PlayCount" => true,
                 "IsFavorite" => true,
                 "NextUnwatched" => true,
+                "LastPlayedDate" => true,
                 _ => false
             };
         }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -114,6 +114,21 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                     {
                         operand.PlayCount = userData.PlayCount;
                         operand.IsFavorite = userData.IsFavorite;
+                        
+                        // Extract LastPlayedDate if available, otherwise use -1 (represents "never played")
+                        if (userData.LastPlayedDate.HasValue)
+                        {
+                            operand.LastPlayedDate = SafeToUnixTimeSeconds(userData.LastPlayedDate.Value);
+                        }
+                        else
+                        {
+                            operand.LastPlayedDate = -1; // Never played - use -1 as sentinel value
+                        }
+                    }
+                    else
+                    {
+                        // Fallback when userData is null - treat as never played
+                        operand.LastPlayedDate = -1;
                     }
                     // If userData is null, keep the fallback values we set above
                 }
@@ -179,12 +194,23 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                                     {
                                         operand.PlayCountByUser[userId] = targetUserData.PlayCount;
                                         operand.IsFavoriteByUser[userId] = targetUserData.IsFavorite;
-                                    }
-                                    else
-                                    {
-                                        // Fallback values
-                                        operand.PlayCountByUser[userId] = userIsPlayed ? 1 : 0;
-                                        operand.IsFavoriteByUser[userId] = false;
+                                        
+                                        // Extract LastPlayedDate if available, otherwise use -1 (represents "never played")
+                                        if (targetUserData.LastPlayedDate.HasValue)
+                                        {
+                                            operand.LastPlayedDateByUser[userId] = SafeToUnixTimeSeconds(targetUserData.LastPlayedDate.Value);
+                                        }
+                                                                else
+                        {
+                            operand.LastPlayedDateByUser[userId] = -1; // Never played - use -1 as sentinel value
+                        }
+                    }
+                    else
+                    {
+                        // Fallback values when targetUserData is null
+                        operand.PlayCountByUser[userId] = userIsPlayed ? 1 : 0;
+                        operand.IsFavoriteByUser[userId] = false;
+                        operand.LastPlayedDateByUser[userId] = -1; // Never played - use -1 as sentinel value
                                     }
                                 }
                                 else

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
@@ -16,7 +16,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             "DateLastRefreshed", 
             "DateLastSaved",
             "DateModified",
-            "ReleaseDate"
+            "ReleaseDate",
+            "LastPlayedDate"
         ];
 
         /// <summary>
@@ -70,7 +71,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             "IsPlayed",
             "IsFavorite", 
             "PlayCount",
-            "NextUnwatched"
+            "NextUnwatched",
+            "LastPlayedDate"
         ];
 
         /// <summary>

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -23,6 +23,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public double DateLastSaved { get; set; } = 0;
         public double DateModified { get; set; } = 0;
         public double ReleaseDate { get; set; } = 0;
+        public double LastPlayedDate { get; set; } = 0;
         public List<string> Tags { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;
         public int PlayCount { get; set; } = 0;
@@ -42,6 +43,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public Dictionary<string, int> PlayCountByUser { get; set; } = [];
         public Dictionary<string, bool> IsFavoriteByUser { get; set; } = [];
         public Dictionary<string, bool> NextUnwatchedByUser { get; set; } = [];
+        public Dictionary<string, double> LastPlayedDateByUser { get; set; } = [];
         
         // Helper methods to check user-specific data
         public bool GetIsPlayedByUser(string userId)
@@ -62,6 +64,11 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public bool GetNextUnwatchedByUser(string userId)
         {
             return NextUnwatchedByUser.TryGetValue(userId, out var value) && value;
+        }
+        
+        public double GetLastPlayedDateByUser(string userId)
+        {
+            return LastPlayedDateByUser.TryGetValue(userId, out var value) ? value : 0;
         }
     }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public double DateLastSaved { get; set; } = 0;
         public double DateModified { get; set; } = 0;
         public double ReleaseDate { get; set; } = 0;
-        public double LastPlayedDate { get; set; } = 0;
+        public double LastPlayedDate { get; set; } = -1;
         public List<string> Tags { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;
         public int PlayCount { get; set; } = 0;
@@ -68,7 +68,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         
         public double GetLastPlayedDateByUser(string userId)
         {
-            return LastPlayedDateByUser.TryGetValue(userId, out var value) ? value : 0;
+            return LastPlayedDateByUser.TryGetValue(userId, out var value) ? value : -1;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The web interface provides access to all available fields for creating playlist 
 > - **"Recently played favorites"**: `Last Played Newer Than 7 days AND Is Favorite = True`
 > - **"Movies watched this year"**: `Last Played After 2024-01-01`
 > - **"Content not played by specific user in 6 months"**: `Last Played Older Than 6 months (for User: John)` (only items played more than 6 months ago)
-> - **"Never played content"**: Use `Is Played` instead, as Last Played rules exclude never-played items by design
+> - **"Never played content"**: Use the field `Is Played` instead, as Last Played rules exclude never-played items by design
 > 
 > **Note**: Relative date calculations use UTC time to ensure consistent behavior across different server timezones. This means "items from the last 3 days" is calculated from the current UTC time, not your local timezone.
 

--- a/README.md
+++ b/README.md
@@ -175,19 +175,27 @@ For local development, see the [dev folder](https://github.com/jyourstone/jellyf
 
 The web interface provides access to all available fields for creating playlist rules:
 
-#### **Content Fields**
-- **Name** - Title of the media item
-- **Media Type** - The type of item (e.g., `Movie`, `Episode`, `Series`, `Music`)
-- **Audio Languages** - The audio language of the movie/TV show.
+#### **Content**
 - **Album** - Album name (for music)
-- **Folder Path** - Location in your library
+- **Audio Languages** - The audio language of the movie/TV show
+- **Name** - Title of the media item
+- **Parental Rating** - Age rating (G, PG, PG-13, R, etc.)
+- **Overview** - Description/summary of the content
+- **Production Year** - Original production year
+- **Release Date** - Original release date of the media
 
-#### **Playback Fields**
-- **Is Played** - Whether the item has been watched/listened to
+#### **Ratings & Playback**
+- **Community Rating** - User ratings (0-10)
+- **Critic Rating** - Professional critic ratings
 - **Is Favorite** - Whether the item is marked as a favorite
-- **Play Count** - Number of times the item has been played
+- **Is Played** - Whether the item has been watched/listened to
+- **Last Played** - When the item was last played (user-specific). Items never played by a user are excluded from all Last Played filtering
 - **Next Unwatched** - Shows only the next unwatched episode in chronological order for TV series
+- **Play Count** - Number of times the item has been played
+- **Runtime (Minutes)** - Duration of the content in minutes
+
 > **Note:** These playback fields can optionally be set to a specific user. This allows you to create rules like "Is Played by user X" or "Is Favorite for user X AND for user Y".
+> 
 > **Next Unwatched**: This field is specifically designed for creating "Continue Watching" style playlists. For TV series, it identifies the next episode a user should watch based on their viewing history:
 > - If a user has watched Season 1 completely and Season 2 episodes 1-3, it shows Season 2 Episode 4
 > - For completely unwatched series, it shows Season 1 Episode 1 (configurable)
@@ -196,33 +204,36 @@ The web interface provides access to all available fields for creating playlist 
 > - **Include unwatched series**: Optional setting to include/exclude Season 1 Episode 1 of completely unwatched series
 > - **⚠️ Note**: Specials (Season 0 episodes) are automatically excluded from the "Next Unwatched" logic to focus on the main storyline
 
-#### **Content Info**
-- **Parental Rating** - Age rating (G, PG, PG-13, R, etc.)
-- **Runtime (Minutes)** - Duration of the content in minutes
+#### **File Info**
+- **Date Modified** - Last file modification date
+- **File Name** - Name of the media file
+- **Folder Path** - Location in your library
 
-#### **Ratings & Dates**
-- **Community Rating** - User ratings (0-10)
-- **Critic Rating** - Professional critic ratings
-- **Production Year** - Original production year
-- **Release Date** - Original release date of the media
-- **Date Created** - When added to your library
-- **Date Last Refreshed** - Last metadata update
-- **Date Last Saved** - Last saved to database
-- **Date Modified** - Last file modification
+#### **Library**
+- **Date Added to Library** - When added to your Jellyfin library
+- **Last Metadata Refresh** - When Jellyfin last updated metadata from online sources
+- **Last Database Save** - When the item's data was last saved to Jellyfin's database
+
+#### **Collections**
+- **People** - Cast and crew (actors, directors, producers, etc.) *for movies and TV shows*
+- **Genres** - Content genres
+- **Studios** - Production studios
+- **Tags** - Custom tags assigned to media items
+- **Artists** - Track-level artists *for music*
+- **Album Artists** - Album-level primary artists *for music*
 
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:
 > - **Exact dates**: Use "After" or "Before" with a specific date (e.g., "2024-01-01")
 > - **Relative dates**: Use "Newer Than" or "Older Than" with a time period (e.g., "3 weeks", "1 month", "2 years")
 > 
+> **Last Played Examples**:
+> - **"Music not played in the last month"**: `Last Played Older Than 1 month` (only items played more than a month ago, excludes never-played)
+> - **"Recently played favorites"**: `Last Played Newer Than 7 days AND Is Favorite = True`
+> - **"Movies watched this year"**: `Last Played After 2024-01-01`
+> - **"Content not played by specific user in 6 months"**: `Last Played Older Than 6 months (for User: John)` (only items played more than 6 months ago)
+> - **"Never played content"**: Use `Is Played` instead, as Last Played rules exclude never-played items by design
+> 
 > **Note**: Relative date calculations use UTC time to ensure consistent behavior across different server timezones. This means "items from the last 3 days" is calculated from the current UTC time, not your local timezone.
-
-#### **Metadata**
-- **People** - Cast and crew (actors, directors, producers, etc.) *for movies and TV shows*
-- **Artists** - Track-level artists *for music*
-- **Album Artists** - Album-level primary artists *for music*
-- **Genres** - Content genres
-- **Studios** - Production studios
-- **Tags** - Custom tags assigned to media items
 
 > **Music Fields**: For music libraries, use **Artists** to find specific artists and **Album Artists** to find music by the primary artist of an album. The **People** field is designed for movies/TV and contains cast/crew information rather than music performers.
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for the Last Played field across the smart playlist plugin, enabling filtering by last played date with sentinel handling for items never played.

New Features:
- Introduce LastPlayedDate and LastPlayedDateByUser properties in the operand model with a -1 sentinel for never-played items
- Populate LastPlayedDate values in the query factory for both current user and specific users
- Extend the query engine to handle LastPlayedDate filtering with standard and relative date operators and exclude never-played items
- Expose LastPlayedDate in the API available fields, configuration, and field definitions
- Update the UI grouping and README documentation to include the new Last Played field and usage examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "Last Played" date filtering in smart playlists, allowing you to filter items based on when they were last played.
  * Expanded available fields for rule creation, including "Release Date," "Date Modified," and new library metadata fields like "Date Added to Library," "Last Metadata Refresh," and "Last Database Save."
  * Added per-user last played date filtering for more personalized playlist rules.

* **Bug Fixes**
  * Items never played are now correctly excluded from "Last Played" date filters.

* **Documentation**
  * Improved and reorganized documentation for available playlist rule fields, with clearer explanations and new examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->