### PR TITLE
add support for music videos

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -211,6 +211,10 @@
                                     <input type="checkbox" is="emby-checkbox" id="mediaTypeAudio" class="emby-checkbox media-type-checkbox" value="Audio">
                                     <span>Music</span>
                                 </label>
+                                <label class="checkboxLabel" for="mediaTypeMusicVideo">
+                                    <input type="checkbox" is="emby-checkbox" id="mediaTypeMusicVideo" class="emby-checkbox media-type-checkbox" value="MusicVideo">
+                                    <span>Music Videos</span>
+                                </label>
                             </div>
                             <div class="fieldDescription">Select the types of media items to include in your playlist. Episodes are individual TV show episodes, while Series are the show containers (shows as a whole). At least one type must be selected.</div>
                         </div>

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -245,7 +245,7 @@
         { Value: "Series", Label: "Series" }, 
         { Value: "Episode", Label: "Episode" }, 
         { Value: "Audio", Label: "Audio (Music)" },
-        { Value: "Music Video", Label: "Music Video" } 
+        { Value: "MusicVideo", Label: "Music Video" } 
     ];
 
     // Helper functions for page-specific state

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -244,7 +244,8 @@
         { Value: "Movie", Label: "Movie" }, 
         { Value: "Series", Label: "Series" }, 
         { Value: "Episode", Label: "Episode" }, 
-        { Value: "Audio", Label: "Audio (Music)" } 
+        { Value: "Audio", Label: "Audio (Music)" },
+        { Value: "Music Video", Label: "Music Video" } 
     ];
 
     // Helper functions for page-specific state

--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -783,6 +783,9 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     case "Series":
                         baseItemKinds.Add(BaseItemKind.Series);
                         break;
+                    case "MusicVideo":
+                        baseItemKinds.Add(BaseItemKind.MusicVideo);
+                        break;
                     default:
                         _logger?.LogWarning("Unknown media type '{MediaType}' - skipping", mediaType);
                         break;
@@ -793,7 +796,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             if (baseItemKinds.Count == 0)
             {
                 _logger?.LogWarning("No valid media types found, falling back to all supported types");
-                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series];
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo];
             }
 
             return [.. baseItemKinds];

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
         public override string Name => "Refresh Video SmartPlaylists";
-        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes)";
+        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes, music videos)";
         public override string Key => "RefreshVideoSmartPlaylists";
 
         protected override string GetHandledMediaTypes()
@@ -39,14 +39,14 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 playlist.MediaTypes.Any(mediaType => 
                     mediaType == "Movie" || 
                     mediaType == "Series" || 
-                    mediaType == "Episode"));
+                    mediaType == "Episode" || mediaType == "MusicVideo"));
         }
 
         protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
         {
             var query = new InternalItemsQuery(user)
             {
-                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series],
+                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo],
                 Recursive = true
             };
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -41,6 +41,7 @@ Make sure you have the following installed on your system:
     - Place movie files in `dev/media/movies/`  
     - Place TV show files in `dev/media/shows/`
     - Place music files in `dev/media/music/`  
+    - Place music video files in `dev/media/musicvideos/`  
 
 ## Notes
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./jellyfin-data/cache:/cache
       - ./media/movies:/movies # You can place some movie files here for testing.
       - ./media/shows:/shows # You can place some tv/episode files here for testing.
+      - ./media/musicvideos:/musicvideos # You can place some music files here for testing.
       - ./media/music:/music # You can place some music files here for testing.
       - ../build_output:/config/plugins/SmartPlaylist # Mount the build output directly into the plugins directory.
     restart: "unless-stopped" 


### PR DESCRIPTION


## Summary by Sourcery

Add support for music videos in the SmartPlaylist plugin by extending media type handling, updating the configuration UI, and adjusting the development environment setup.

New Features:
- Support music videos as a selectable media type in smart playlists

Enhancements:
- Include MusicVideo in the playlist refresh task description and media type filtering logic
- Extend BaseItemKind mapping and fallback lists to handle MusicVideo items

Documentation:
- Add a Music Videos checkbox in the configuration UI
- Update the development README and Docker Compose setup to include a musicvideos directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Music Videos" as a selectable media type in SmartPlaylist configuration and filtering.
  * Playlists and media queries now include music videos alongside movies, series, episodes, and music.

* **Documentation**
  * Updated instructions to include guidance for adding music video test files.

* **Chores**
  * Enhanced Docker Compose setup to support music video test media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->