### PR TITLE
Fixed caching issue which could cause wrong contents showing up in playlists

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -752,6 +752,12 @@ namespace Jellyfin.Plugin.SmartPlaylist
 
             return null;
         }
+        /// <summary>
+        /// Gets all user media for a playlist, filtering by the specified media types.
+        /// </summary>
+        /// <param name="user">The user to get media for.</param>
+        /// <param name="mediaTypes">The media types to filter by, or null/empty to include all supported media types.</param>
+        /// <returns>Enumerable of BaseItem matching the specified media types.</returns>
         public IEnumerable<BaseItem> GetAllUserMediaForPlaylist(User user, List<string> mediaTypes)
         {
             return GetAllUserMedia(user, mediaTypes);

--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         Task EnablePlaylistAsync(SmartPlaylistDto dto, CancellationToken cancellationToken = default);
         Task DisablePlaylistAsync(SmartPlaylistDto dto, CancellationToken cancellationToken = default);
         Task<(bool Success, string Message)> TryRefreshAllPlaylistsAsync(CancellationToken cancellationToken = default);
+        IEnumerable<BaseItem> GetAllUserMediaForPlaylist(User user, List<string> mediaTypes);
     }
 
     public class PlaylistService(
@@ -751,6 +752,11 @@ namespace Jellyfin.Plugin.SmartPlaylist
 
             return null;
         }
+        public IEnumerable<BaseItem> GetAllUserMediaForPlaylist(User user, List<string> mediaTypes)
+        {
+            return GetAllUserMedia(user, mediaTypes);
+        }
+
         private IEnumerable<BaseItem> GetAllUserMedia(User user, List<string> mediaTypes = null)
         {
             var query = new InternalItemsQuery(user)

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
     /// <summary>
     /// Cache key for media types to avoid string collision issues
     /// </summary>
-    internal readonly record struct MediaTypesKey
+    internal readonly record struct MediaTypesKey : IEquatable<MediaTypesKey>
     {
         private readonly string[] _sortedTypes;
 
@@ -37,6 +37,32 @@ namespace Jellyfin.Plugin.SmartPlaylist
 
             var sorted = mediaTypes.OrderBy(x => x, StringComparer.Ordinal).ToArray();
             return new MediaTypesKey(sorted);
+        }
+
+        public bool Equals(MediaTypesKey other)
+        {
+            if (_sortedTypes.Length != other._sortedTypes.Length)
+                return false;
+
+            for (int i = 0; i < _sortedTypes.Length; i++)
+            {
+                if (!string.Equals(_sortedTypes[i], other._sortedTypes[i], StringComparison.Ordinal))
+                    return false;
+            }
+
+            return true;
+        }
+
+
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var type in _sortedTypes)
+            {
+                hash.Add(type, StringComparer.Ordinal);
+            }
+            return hash.ToHashCode();
         }
 
         public override string ToString()

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -309,10 +309,11 @@ namespace Jellyfin.Plugin.SmartPlaylist
                                 // OPTIMIZATION: Get media specifically for this playlist's media types using cache
                                 // This ensures Movie playlists only get movies, not episodes/series, while avoiding redundant queries
                                 var mediaTypesKey = MediaTypesKey.Create(dto.MediaTypes);
+                                var mediaTypesForClosure = dto.MediaTypes; // Avoid capturing entire dto in closure
                                 var playlistSpecificMedia = userMediaTypeCache.GetOrAdd(mediaTypesKey, _ =>
                                     new Lazy<BaseItem[]>(() =>
                                     {
-                                        var media = playlistService.GetAllUserMediaForPlaylist(playlistUser, dto.MediaTypes).ToArray();
+                                        var media = playlistService.GetAllUserMediaForPlaylist(playlistUser, mediaTypesForClosure).ToArray();
                                         logger.LogDebug("Cached {MediaCount} items for MediaTypes [{MediaTypes}] for user '{Username}'", 
                                             media.Length, mediaTypesKey, user.Username);
                                         return media;

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -40,14 +40,14 @@ namespace Jellyfin.Plugin.SmartPlaylist
             return new MediaTypesKey(sorted);
         }
 
-        public bool Equals(MediaTypesKey other)
-        {
-            // Handle null arrays (default struct case) and use SequenceEqual for cleaner comparison
-            var thisArray = _sortedTypes ?? [];
-            var otherArray = other._sortedTypes ?? [];
-            
-            return thisArray.AsSpan().SequenceEqual(otherArray.AsSpan());
-        }
+                    public bool Equals(MediaTypesKey other)
+            {
+                // Handle null arrays (default struct case) and use SequenceEqual for cleaner comparison
+                var thisArray = _sortedTypes ?? [];
+                var otherArray = other._sortedTypes ?? [];
+                
+                return thisArray.AsSpan().SequenceEqual(otherArray.AsSpan());
+            }
 
 
 
@@ -310,6 +310,9 @@ namespace Jellyfin.Plugin.SmartPlaylist
                                 // This ensures Movie playlists only get movies, not episodes/series, while avoiding redundant queries
                                 var mediaTypesKey = MediaTypesKey.Create(dto.MediaTypes);
                                 var mediaTypesForClosure = dto.MediaTypes; // Avoid capturing entire dto in closure
+                                // NOTE: Lazy<T> caches exceptions. This is intentional for database operations
+                                // where failures typically indicate serious issues that should fail fast
+                                // rather than retry repeatedly during the same scheduled task execution.
                                 var playlistSpecificMedia = userMediaTypeCache.GetOrAdd(mediaTypesKey, _ =>
                                     new Lazy<BaseItem[]>(() =>
                                     {

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -316,7 +316,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                                         logger.LogDebug("Cached {MediaCount} items for MediaTypes [{MediaTypes}] for user '{Username}'", 
                                             media.Length, mediaTypesKey, user.Username);
                                         return media;
-                                    })
+                                    }, LazyThreadSafetyMode.ExecutionAndPublication)
                                 ).Value;
                                 
                                 logger.LogDebug("Playlist {PlaylistName} with MediaTypes [{MediaTypes}] has {PlaylistSpecificCount} specific items vs {CachedCount} cached items", 


### PR DESCRIPTION
## Summary by Sourcery

Implement media-type-specific caching in playlist refresh tasks to eliminate redundant media queries and prevent incorrect content from appearing in playlists.

Bug Fixes:
- Fix wrong playlist contents by caching and retrieving media per specific media types instead of using a generic cached list

Enhancements:
- Introduce MediaTypesKey struct to generate stable cache keys from sorted, deduplicated media type lists
- Use a ConcurrentDictionary of Lazy<BaseItem[]> in RefreshPlaylistsTaskBase to cache user media by media types
- Instantiate PlaylistService only once per user rather than per playlist to reduce overhead
- Extend IPlaylistService with GetAllUserMediaForPlaylist to support media-type-specific retrieval