### PR TITLE
Added new "Collections" rule field that searches for items belonging to a specific collection.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,21 @@ jobs:
       - name: Setup jq
         run: sudo apt-get install -y jq
 
+      - name: Check if tag is preview
+        id: check_preview
+        run: |
+          # Get the tag message and check if it contains "preview"
+          TAG_MESSAGE=$(git tag -l --format='%(contents:subject)' ${{ github.ref_name }})
+          if echo "$TAG_MESSAGE" | grep -qi "preview"; then
+            echo "is_preview=true" >> $GITHUB_OUTPUT
+            echo "PRERELEASE_STR=true" >> $GITHUB_OUTPUT
+            echo "Preview tag detected: $TAG_MESSAGE"
+          else
+            echo "is_preview=false" >> $GITHUB_OUTPUT
+            echo "PRERELEASE_STR=false" >> $GITHUB_OUTPUT
+            echo "Release tag detected: $TAG_MESSAGE"
+          fi
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -55,8 +70,8 @@ jobs:
           name: Release ${{ github.ref_name }}
           files: ./Jellyfin.Plugin.SmartPlaylist_${{ github.ref_name }}.zip
           draft: false
-          # convert "true"/"false" string to boolean
-          prerelease: ${{ fromJSON(env.PRERELEASE_STR) }}
+          # Use the dynamically determined prerelease status
+          prerelease: ${{ steps.check_preview.outputs.is_preview }}
           generate_release_notes: true
           token: ${{ secrets.PAT }}
 

--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -662,6 +662,41 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     new { Value = "NewerThan", Label = "newer than" },
                     new { Value = "OlderThan", Label = "older than" }
                 },
+                FieldOperators = new Dictionary<string, string[]>
+                {
+                    // List fields - multi-valued fields
+                    ["Collections"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["People"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["Genres"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["Studios"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["Tags"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["Artists"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["AlbumArtists"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    ["AudioLanguages"] = ["Contains", "NotContains", "IsIn", "IsNotIn", "MatchRegex"],
+                    
+                    // Simple fields - single-choice fields
+                    ["ItemType"] = ["Equal", "NotEqual"],
+                    
+                    // Boolean fields - true/false fields
+                    ["IsPlayed"] = ["Equal", "NotEqual"],
+                    ["IsFavorite"] = ["Equal", "NotEqual"],
+                    ["NextUnwatched"] = ["Equal", "NotEqual"],
+                    
+                    // Numeric fields - number-based fields
+                    ["ProductionYear"] = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"],
+                    ["CommunityRating"] = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"],
+                    ["CriticRating"] = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"],
+                    ["RuntimeMinutes"] = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"],
+                    ["PlayCount"] = ["Equal", "NotEqual", "GreaterThan", "LessThan", "GreaterThanOrEqual", "LessThanOrEqual"],
+                    
+                    // Date fields - date/time fields
+                    ["DateCreated"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"],
+                    ["DateLastRefreshed"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"],
+                    ["DateLastSaved"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"],
+                    ["DateModified"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"],
+                    ["ReleaseDate"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"],
+                    ["LastPlayedDate"] = ["Equal", "NotEqual", "After", "Before", "NewerThan", "OlderThan"]
+                },
                 OrderOptions = new[]
                 {
                     new { Value = "NoOrder", Label = "No Order" },

--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -636,6 +636,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                 },
                 CollectionFields = new[]
                 {
+                    new { Value = "CollectionName", Label = "Collection" },
                     new { Value = "People", Label = "People" },
                     new { Value = "Genres", Label = "Genres" },
                     new { Value = "Studios", Label = "Studios" },

--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -636,7 +636,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                 },
                 CollectionFields = new[]
                 {
-                    new { Value = "CollectionName", Label = "Collection" },
+                    new { Value = "Collections", Label = "Collections" },
                     new { Value = "People", Label = "People" },
                     new { Value = "Genres", Label = "Genres" },
                     new { Value = "Studios", Label = "Studios" },

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -12,7 +12,7 @@
     
     // Field type constants to avoid duplication
     const FIELD_TYPES = {
-        LIST_FIELDS: ['People', 'Genres', 'Studios', 'Tags', 'Artists', 'AlbumArtists'],
+        LIST_FIELDS: ['Collections', 'People', 'Genres', 'Studios', 'Tags', 'Artists', 'AlbumArtists'],
         NUMERIC_FIELDS: ['ProductionYear', 'CommunityRating', 'CriticRating', 'RuntimeMinutes', 'PlayCount'],
         DATE_FIELDS: ['DateCreated', 'DateLastRefreshed', 'DateLastSaved', 'DateModified', 'ReleaseDate', 'LastPlayedDate'],
         BOOLEAN_FIELDS: ['IsPlayed', 'IsFavorite', 'NextUnwatched'],

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -703,6 +703,9 @@
             const option = document.createElement('option');
             option.value = opt.Value;
             option.textContent = opt.Label;
+            if (currentValue && opt.Value === currentValue) {
+                option.selected = true;
+            }
             select.appendChild(option);
         });
         valueContainer.appendChild(select);
@@ -730,6 +733,9 @@
             const option = document.createElement('option');
             option.value = opt.Value;
             option.textContent = opt.Label;
+            if (currentValue && opt.Value === currentValue) {
+                option.selected = true;
+            }
             select.appendChild(option);
         });
         valueContainer.appendChild(select);
@@ -744,6 +750,9 @@
         input.className = 'emby-input rule-value-input';
         input.placeholder = 'Value';
         input.style.width = '100%';
+        if (currentValue) {
+            input.value = currentValue;
+        }
         valueContainer.appendChild(input);
     }
 
@@ -754,9 +763,9 @@
         const isRelativeDateOperator = RELATIVE_DATE_OPERATORS.includes(currentOperator);
         
         if (isRelativeDateOperator) {
-            handleRelativeDateInput(valueContainer);
+            handleRelativeDateInput(valueContainer, currentValue);
         } else {
-            handleAbsoluteDateInput(valueContainer);
+            handleAbsoluteDateInput(valueContainer, currentValue);
         }
     }
 
@@ -825,6 +834,9 @@
         input.className = 'emby-input rule-value-input';
         input.placeholder = 'Value';
         input.style.width = '100%';
+        if (currentValue) {
+            input.value = currentValue;
+        }
         valueContainer.appendChild(input);
     }
 

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -543,6 +543,26 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             
             operand.OfficialRating = baseItem.OfficialRating ?? "";
             
+            // Extract CollectionName property using reflection
+            try
+            {
+                var collectionNameProperty = baseItem.GetType().GetProperty("CollectionName");
+                if (collectionNameProperty != null)
+                {
+                    var collectionNameValue = collectionNameProperty.GetValue(baseItem) as string;
+                    operand.CollectionName = collectionNameValue ?? "";
+                }
+                else
+                {
+                    operand.CollectionName = "";
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogDebug(ex, "Failed to extract CollectionName for item {Name}", baseItem.Name);
+                operand.CollectionName = "";
+            }
+            
             // Extract Overview property using reflection
             try
             {
@@ -824,8 +844,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         /// </summary>
         /// <param name="userDataManager">The user data manager instance.</param>
         /// <param name="userId">The user ID to look up.</param>
-        /// <returns>The user if found, otherwise null.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when reflection fails to access the user manager.</exception>
+        /// <returns>The user object if found, null otherwise.</returns>
         public static User GetUserById(IUserDataManager userDataManager, Guid userId)
         {
             if (userDataManager == null)

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         /// </summary>
         public static readonly HashSet<string> ListFields =
         [
-            "CollectionName",
+            "Collections",
             "People",
             "Genres", 
             "Studios",

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/FieldDefinitions.cs
@@ -25,6 +25,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         /// </summary>
         public static readonly HashSet<string> ListFields =
         [
+            "CollectionName",
             "People",
             "Genres", 
             "Studios",

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -32,8 +32,8 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public List<string> Artists { get; set; } = [];
         public List<string> AlbumArtists { get; set; } = [];
         
-        // Collection field - indicates which collection this item belongs to
-        public string CollectionName { get; set; } = "";
+        // Collections field - indicates which collections this item belongs to  
+        public List<string> Collections { get; set; } = [];
         
         // User-specific data - Store user ID -> data mappings
         // These will be populated based on which users are referenced in rules

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -32,6 +32,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public List<string> Artists { get; set; } = [];
         public List<string> AlbumArtists { get; set; } = [];
         
+        // Collection field - indicates which collection this item belongs to
+        public string CollectionName { get; set; } = "";
+        
         // User-specific data - Store user ID -> data mappings
         // These will be populated based on which users are referenced in rules
         public Dictionary<string, bool> IsPlayedByUser { get; set; } = [];

--- a/README.md
+++ b/README.md
@@ -256,10 +256,8 @@ The web interface provides access to all available fields for creating playlist 
 - **Artists** - Track-level artists *for music*
 - **Album Artists** - Album-level primary artists *for music*
 
-> **Collections Field Details**: The **Collections** field captures all Jellyfin collections (both user-created and automatic from TMDB) that contain the media item. This is useful for creating playlists like "All items from my Marvel Collection" or "Complete Lord of the Rings Collection".
+> **Collections Field Details**: The **Collections** field captures all Jellyfin collections that contain the media item. This is useful for creating playlists like "All items from Movie Franchise"".
  
-> **⚠️ Important**: This field does NOT work with manually created Jellyfin collections (user-created groupings in the Jellyfin interface).
-
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:
 > - **Exact dates**: Use "After" or "Before" with a specific date (e.g., "2024-01-01")
 > - **Relative dates**: Use "Newer Than" or "Older Than" with a time period (e.g., "3 weeks", "1 month", "2 years")

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Here are some popular playlist types you can create:
 - **Unwatched Action Movies** - Is Played = False AND Genre contains "Action"
 - **Recent Additions** - Date Created newer than "2 weeks"
 - **Holiday Classics** - Tags contain "Christmas" AND Production Year before "2000"
-- **Complete Franchise Collection** - Collection contains "Jurassic Park" (includes all movies in the franchise)
+- **Complete Franchise Collection** - Collections contains "Movie Franchise" (includes all movies in the franchise)
 
 #### **Music**
 - **Workout Mix** - Genre contains "Electronic" OR "Rock" AND Max Play Time 45 minutes
@@ -173,6 +173,34 @@ Here are some of the planned features for future updates. Feel free to contribut
 
 ### Building Locally
 For local development, see the [dev folder](https://github.com/jyourstone/jellyfin-smartplaylist-plugin/tree/master/dev)
+
+### Adding New Rule Fields
+
+When adding new rule fields to the plugin, ensure they are categorized correctly in the UI field types (`config.js`):
+
+#### Field Type Categories
+
+- **`LIST_FIELDS`** - Multi-valued fields (Collections, People, Genres, Studios, Tags, Artists, AlbumArtists)
+  - **Operators**: Contains, NotContains, IsIn, IsNotIn, MatchRegex
+  - **Use for**: Fields that can have multiple values per item
+
+- **`NUMERIC_FIELDS`** - Number-based fields (ProductionYear, CommunityRating, RuntimeMinutes, PlayCount)  
+  - **Operators**: Equal, NotEqual, GreaterThan, LessThan, GreaterThanOrEqual, LessThanOrEqual
+  - **Use for**: Fields with numeric values
+
+- **`DATE_FIELDS`** - Date/time fields (DateCreated, ReleaseDate, LastPlayedDate)
+  - **Operators**: Equal, NotEqual, After, Before, NewerThan, OlderThan
+  - **Use for**: Date and timestamp fields
+
+- **`BOOLEAN_FIELDS`** - True/false fields (IsPlayed, IsFavorite, NextUnwatched)
+  - **Operators**: Equal, NotEqual  
+  - **Use for**: Boolean/checkbox fields
+
+- **`SIMPLE_FIELDS`** - Single-choice fields (ItemType)
+  - **Operators**: Equal, NotEqual
+  - **Use for**: Dropdown/select fields with predefined options
+
+**Important**: Always add new fields to the correct category to ensure proper operator availability and UI behavior.
 
 ## 🔧 Advanced Configuration
 
@@ -229,7 +257,7 @@ The web interface provides access to all available fields for creating playlist 
 - **Album Artists** - Album-level primary artists *for music*
 
 > **Collections Field Details**: The **Collections** field captures all Jellyfin collections (both user-created and automatic from TMDB) that contain the media item. This is useful for creating playlists like "All items from my Marvel Collection" or "Complete Lord of the Rings Collection".
-> 
+ 
 > **⚠️ Important**: This field does NOT work with manually created Jellyfin collections (user-created groupings in the Jellyfin interface).
 
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The web interface provides access to all available fields for creating playlist 
 - **Last Database Save** - When the item's data was last saved to Jellyfin's database
 
 #### **Collections**
-- **Collection** - Official movie franchise/collection names from TMDB (e.g., "Jurassic Park", "The Matrix")
+- **Collections** - All Jellyfin collections that contain the media item
 - **People** - Cast and crew (actors, directors, producers, etc.) *for movies and TV shows*
 - **Genres** - Content genres
 - **Studios** - Production studios
@@ -228,7 +228,7 @@ The web interface provides access to all available fields for creating playlist 
 - **Artists** - Track-level artists *for music*
 - **Album Artists** - Album-level primary artists *for music*
 
-> **Collection Field Details**: The **Collection** field captures official movie franchise collections that are automatically populated from external sources metadata. This is useful for creating playlists like "All Marvel Movies" or "Complete Lord of the Rings Collection".
+> **Collections Field Details**: The **Collections** field captures all Jellyfin collections (both user-created and automatic from TMDB) that contain the media item. This is useful for creating playlists like "All items from my Marvel Collection" or "Complete Lord of the Rings Collection".
 > 
 > **⚠️ Important**: This field does NOT work with manually created Jellyfin collections (user-created groupings in the Jellyfin interface).
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Here are some popular playlist types you can create:
 - **Unwatched Action Movies** - Is Played = False AND Genre contains "Action"
 - **Recent Additions** - Date Created newer than "2 weeks"
 - **Holiday Classics** - Tags contain "Christmas" AND Production Year before "2000"
+- **Complete Franchise Collection** - Collection contains "Jurassic Park" (includes all movies in the franchise)
 
 #### **Music**
 - **Workout Mix** - Genre contains "Electronic" OR "Rock" AND Max Play Time 45 minutes
@@ -219,12 +220,17 @@ The web interface provides access to all available fields for creating playlist 
 - **Last Database Save** - When the item's data was last saved to Jellyfin's database
 
 #### **Collections**
+- **Collection** - Official movie franchise/collection names from TMDB (e.g., "Jurassic Park", "The Matrix")
 - **People** - Cast and crew (actors, directors, producers, etc.) *for movies and TV shows*
 - **Genres** - Content genres
 - **Studios** - Production studios
 - **Tags** - Custom tags assigned to media items
 - **Artists** - Track-level artists *for music*
 - **Album Artists** - Album-level primary artists *for music*
+
+> **Collection Field Details**: The **Collection** field captures official movie franchise collections that are automatically populated from external sources metadata. This is useful for creating playlists like "All Marvel Movies" or "Complete Lord of the Rings Collection".
+> 
+> **⚠️ Important**: This field does NOT work with manually created Jellyfin collections (user-created groupings in the Jellyfin interface).
 
 > **Date Filtering**: Date fields support both exact date comparisons and relative date filtering:
 > - **Exact dates**: Use "After" or "Before" with a specific date (e.g., "2024-01-01")


### PR DESCRIPTION
## Summary by Sourcery

Add support for a new Collections field in smart playlist rules by extending the query engine, UI, and documentation to enable filtering items based on their Jellyfin collection memberships.

New Features:
- Add a new Collections rule field for filtering playlist items by Jellyfin collections

Enhancements:
- Extend the query engine with ExtractCollections logic and caching for efficient collection membership lookups
- Integrate a needsCollections flag throughout the filtering pipeline and treat Collections as an expensive extraction field
- Enhance the UI config script to preserve current dropdown and input values when editing rules

Documentation:
- Update README and API controller to document the new Collections field, its operators, and usage examples