### PR TITLE
Added support for media types Home Videos and Photos.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -252,7 +252,9 @@
         { Value: "Series", Label: "Series" }, 
         { Value: "Episode", Label: "Episode" }, 
         { Value: "Audio", Label: "Audio (Music)" },
-        { Value: "MusicVideo", Label: "Music Video" } 
+        { Value: "MusicVideo", Label: "Music Video" },
+        { Value: "Video", Label: "Video (Home Video)" },
+        { Value: "Photo", Label: "Photo (Home Photo)" }
     ];
 
     // Generate media type checkboxes from the mediaTypes array

--- a/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
@@ -18,15 +18,20 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         // Music Video Types
         public const string MusicVideo = nameof(MusicVideo);
         
+        // Home Video and Photo Types (matching Jellyfin's backend types)
+        public const string Video = nameof(Video);
+        public const string Photo = nameof(Photo);
+        
         /// <summary>
         /// Gets all supported media types as an array
         /// </summary>
-        public static readonly string[] All = [Episode, Series, Movie, Audio, MusicVideo];
+        public static readonly string[] All = [Episode, Series, Movie, Audio, MusicVideo, Video, Photo];
         
         /// <summary>
-        /// Gets video media types (Movie, Series, Episode, MusicVideo)
+        /// Gets video media types (Movie, Series, Episode, MusicVideo, Video, Photo)
+        /// Note: Photo is included here because it's part of the same library type as Video
         /// </summary>
-        public static readonly string[] Video = [Movie, Series, Episode, MusicVideo];
+        public static readonly string[] VideoTypes = [Movie, Series, Episode, MusicVideo, Video, Photo];
         
         /// <summary>
         /// Gets TV media types (Series, Episode)

--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -917,7 +917,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     return "Audio";
                 }
                 
-                bool hasVideoContent = dto.MediaTypes.Any(mt => MediaTypes.Video.Contains(mt));
+                bool hasVideoContent = dto.MediaTypes.Any(mt => MediaTypes.VideoTypes.Contains(mt));
                 bool hasAudioContent = dto.MediaTypes.Any(mt => MediaTypes.AudioOnly.Contains(mt));
                 
                 if (hasVideoContent && !hasAudioContent)

--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -790,7 +790,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             // If no media types specified, return all supported types (backward compatibility)
             if (mediaTypes == null || mediaTypes.Count == 0)
             {
-                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo];
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo];
             }
 
             var baseItemKinds = new List<BaseItemKind>();
@@ -813,6 +813,12 @@ namespace Jellyfin.Plugin.SmartPlaylist
                         break;
                     case MediaTypes.MusicVideo:
                         baseItemKinds.Add(BaseItemKind.MusicVideo);
+                        break;
+                    case MediaTypes.Video:
+                        baseItemKinds.Add(BaseItemKind.Video);
+                        break;
+                    case MediaTypes.Photo:
+                        baseItemKinds.Add(BaseItemKind.Photo);
                         break;
                     default:
                         _logger?.LogWarning("Unknown media type '{MediaType}' - skipping", mediaType);
@@ -839,7 +845,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             if (baseItemKinds.Count == 0)
             {
                 _logger?.LogWarning("No valid media types found, falling back to all supported types");
-                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo];
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo];
             }
 
             return [.. baseItemKinds];

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -945,11 +945,12 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 operand.AudioLanguages = [];
             }
 
-            // Extract resolution from media streams - always extract for performance (cheap operation)
-            ExtractResolution(operand, baseItem, logger);
-            
-            // Extract framerate from media streams - always extract for performance (cheap operation)
-            ExtractFramerate(operand, baseItem, logger);
+            // Extract resolution/framerate only for items that can have video streams (exclude audio and photos)
+            if (baseItem is not Photo and not Audio)
+            {
+                ExtractResolution(operand, baseItem, logger);
+                ExtractFramerate(operand, baseItem, logger);
+            }
             
             // Extract collections - only when needed for performance
             if (options.ExtractCollections)

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -6,6 +6,8 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.Audio;
+using Video = MediaBrowser.Controller.Entities.Video;
+using Photo = MediaBrowser.Controller.Entities.Photo;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Data.Entities;
@@ -1051,6 +1053,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
                 Movie => MediaTypes.Movie,
                 Audio => MediaTypes.Audio,
                 MusicVideo => MediaTypes.MusicVideo,
+                // Handle Video and Photo types for Home Videos and Photos (same format as other media types)
+                Video => MediaTypes.Video,
+                Photo => MediaTypes.Photo,
                 _ => item.GetType().Name
             };
         }

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
         public override string Name => "Refresh Video SmartPlaylists";
-        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes, music videos)";
+        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes, music videos, home videos, home photos)";
         public override string Key => "RefreshVideoSmartPlaylists";
 
         protected override string GetHandledMediaTypes()
@@ -38,14 +38,14 @@ namespace Jellyfin.Plugin.SmartPlaylist
             return playlists.Where(playlist => 
                 playlist.MediaTypes != null && 
                 playlist.MediaTypes.Any(mediaType => 
-                    MediaTypes.Video.Contains(mediaType)));
+                    MediaTypes.VideoTypes.Contains(mediaType)));
         }
 
         protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
         {
             var query = new InternalItemsQuery(user)
             {
-                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo],
+                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo],
                 Recursive = true
             };
 

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshVideoPlaylistsTask.cs
@@ -24,8 +24,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
         IUserDataManager userDataManager,
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public override string Name => "Refresh Video SmartPlaylists";
-        public override string Description => "Refresh all video SmartPlaylists (movies, series, episodes, music videos, home videos, home photos)";
+        public override string Name => "Refresh Video/Photo SmartPlaylists";
+        public override string Description => "Refresh all video/photo SmartPlaylists (movies, series, episodes, music videos, home videos, home photos)";
         public override string Key => "RefreshVideoSmartPlaylists";
 
         protected override string GetHandledMediaTypes()

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requires Jellyfin version `10.10.0` and newer.
 - ⚙️ **Settings** - Configure default settings and trigger a manual refresh for all playlists at any time.
 - 📦 **Export/Import** - Export all playlists to a ZIP file for backup or transfer between Jellyfin instances. Import playlists with duplicate detection.
 - 🛠️ **Advanced Options** - Support for regex patterns, date ranges, and more.
-- 🎵 **Media Types** - Works with movies, series, episodes, music, and music videos.
+- 🎵 **Media Types** - Works with movies, series, episodes, music, music videos, home videos and photos.
 
 ## ⚙️ Configuration
 
@@ -158,6 +158,12 @@ Here are some popular playlist types you can create:
 - **Discover New Music** - Play Count = 0 AND Date Created newer than "1 month"
 - **Top Rated Favorites** - Is Favorite = True AND Community Rating greater than 8
 - **Rediscover Music** - Last Played older than 6 months
+
+#### **Home Videos & Photos**
+- **Recent Family Memories** - Date Created newer than "3 months" (both videos and photos)
+- **Vacation Videos Only** - Tags contain "Vacation" (select Home Videos media type)
+- **Photo Slideshow** - Production Year = 2024 (select Home Photos media type)
+- **Birthday Memories** - File Name contains "birthday" OR Tags contain "Birthday"
 
 #### **Advanced Examples**
 - **Weekend Binge Queue** - Next Unwatched = True (excluding unwatched series) for started shows only

--- a/dev/build-local.sh
+++ b/dev/build-local.sh
@@ -26,6 +26,7 @@ cp ../images/logo.jpg $OUTPUT_DIR/logo.jpg
 
 # Create the Configuration directory and copy the logging file for debug logs
 mkdir -p $OUTPUT_DIR/Configuration
+mkdir -p jellyfin-data/config/config
 cp logging.json jellyfin-data/config/config/logging.json
 
 echo ""

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -15,5 +15,6 @@ services:
       - ./media/shows:/shows # You can place some tv/episode files here for testing.
       - ./media/musicvideos:/musicvideos # You can place some music video files here for testing.
       - ./media/music:/music # You can place some music files here for testing.
+      - ./media/homevideosandphotos:/homevideosandphotos # You can place some home videos and photos here for testing.
       - ../build_output:/config/plugins/SmartPlaylist # Mount the build output directly into the plugins directory.
     restart: "unless-stopped" 


### PR DESCRIPTION
- Updated README to include home videos and photos in the media types supported by the plugin.
- Modified PlaylistService to return home videos and photos as valid media types.
- Updated RefreshVideoPlaylistsTask to refresh playlists for home videos and photos.
- Enhanced configuration to allow selection of home video and photo types.
- Adjusted MediaTypes constants to include Video and Photo types.
- Updated query engine to handle Video and Photo types appropriately.
- Modified docker-compose to include a directory for home videos and photos for testing.

Closes https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/93

## Summary by Sourcery

Add support for home video and photo media types throughout the SmartPlaylist plugin

New Features:
- Introduce Video and Photo media types in MediaTypes constants and BaseItemKind mappings
- Extend PlaylistService and RefreshVideoPlaylistsTask to handle home videos and photos in smart playlists
- Enhance the query engine factory to map Video and Photo entities to the new media types
- Add UI configuration entries for selecting home videos and photos as media types

Build:
- Update dev build script and docker-compose configuration to mount home videos and photos directories for testing

Documentation:
- Update README and example playlists to include home videos and photos