### PR TITLE
Added support for Books and Audio Books.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -98,7 +98,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
             {
                 // Find both audio and video refresh tasks
                 var audioTask = _taskManager.ScheduledTasks.FirstOrDefault(t => t.ScheduledTask.Key == "RefreshAudioSmartPlaylists");
-                var videoTask = _taskManager.ScheduledTasks.FirstOrDefault(t => t.ScheduledTask.Key == "RefreshVideoSmartPlaylists");
+                var mediaTask = _taskManager.ScheduledTasks.FirstOrDefault(t => t.ScheduledTask.Key == "RefreshMediaSmartPlaylists");
                 
                 bool anyTaskTriggered = false;
                 
@@ -113,15 +113,15 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     _logger.LogWarning("Audio SmartPlaylist refresh task not found");
                 }
                 
-                if (videoTask != null)
+                if (mediaTask != null)
                 {
-                    _logger.LogInformation("Triggering Video SmartPlaylist refresh task");
-                    _taskManager.Execute(videoTask, new TaskOptions());
+                    _logger.LogInformation("Triggering Media SmartPlaylist refresh task");
+                    _taskManager.Execute(mediaTask, new TaskOptions());
                     anyTaskTriggered = true;
                 }
                 else
                 {
-                    _logger.LogWarning("Video SmartPlaylist refresh task not found");
+                    _logger.LogWarning("Media SmartPlaylist refresh task not found");
                 }
                 
                 if (!anyTaskTriggered)

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -254,7 +254,9 @@
         { Value: "Audio", Label: "Audio (Music)" },
         { Value: "MusicVideo", Label: "Music Video" },
         { Value: "Video", Label: "Video (Home Video)" },
-        { Value: "Photo", Label: "Photo (Home Photo)" }
+        { Value: "Photo", Label: "Photo (Home Photo)" },
+        { Value: "Book", Label: "Book" },
+        { Value: "AudioBook", Label: "Audio Book" }
     ];
 
     // Generate media type checkboxes from the mediaTypes array

--- a/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
@@ -22,25 +22,35 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         public const string Video = nameof(Video);
         public const string Photo = nameof(Photo);
         
+        // Book Types
+        public const string Book = nameof(Book);
+        public const string AudioBook = nameof(AudioBook);
+        
         /// <summary>
         /// Gets all supported media types as an array
         /// </summary>
-        public static readonly string[] All = [Episode, Series, Movie, Audio, MusicVideo, Video, Photo];
+        public static readonly string[] All = [Episode, Series, Movie, Audio, MusicVideo, Video, Photo, Book, AudioBook];
         
         /// <summary>
-        /// Gets video media types (Movie, Series, Episode, MusicVideo, Video, Photo)
-        /// Note: Photo is included here because it's part of the same library type as Video
+        /// Gets non-audio media types (everything except Audio and AudioBook)
         /// </summary>
-        public static readonly string[] VideoTypes = [Movie, Series, Episode, MusicVideo, Video, Photo];
+        public static readonly string[] NonAudioTypes = [Movie, Series, Episode, MusicVideo, Video, Photo, Book];
+        
+        /// <summary>
+        /// Gets audio-only media types (Audio, AudioBook)
+        /// </summary>
+        public static readonly string[] AudioOnly = [Audio, AudioBook];
+        
+        /// <summary>
+        /// Gets book media types (Book, AudioBook)
+        /// </summary>
+        public static readonly string[] BookTypes = [Book, AudioBook];
         
         /// <summary>
         /// Gets TV media types (Series, Episode)
         /// </summary>
         public static readonly string[] TV = [Series, Episode];
         
-        /// <summary>
-        /// Gets audio-only media types (Audio)
-        /// </summary>
-        public static readonly string[] AudioOnly = [Audio];
+
     }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/PlaylistService.cs
@@ -790,7 +790,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             // If no media types specified, return all supported types (backward compatibility)
             if (mediaTypes == null || mediaTypes.Count == 0)
             {
-                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo];
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo, BaseItemKind.Book, BaseItemKind.AudioBook];
             }
 
             var baseItemKinds = new List<BaseItemKind>();
@@ -820,6 +820,12 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     case MediaTypes.Photo:
                         baseItemKinds.Add(BaseItemKind.Photo);
                         break;
+                    case MediaTypes.Book:
+                        baseItemKinds.Add(BaseItemKind.Book);
+                        break;
+                    case MediaTypes.AudioBook:
+                        baseItemKinds.Add(BaseItemKind.AudioBook);
+                        break;
                     default:
                         _logger?.LogWarning("Unknown media type '{MediaType}' - skipping", mediaType);
                         break;
@@ -845,7 +851,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             if (baseItemKinds.Count == 0)
             {
                 _logger?.LogWarning("No valid media types found, falling back to all supported types");
-                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo];
+                return [BaseItemKind.Movie, BaseItemKind.Audio, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo, BaseItemKind.Book, BaseItemKind.AudioBook];
             }
 
             return [.. baseItemKinds];
@@ -917,7 +923,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                     return "Audio";
                 }
                 
-                bool hasVideoContent = dto.MediaTypes.Any(mt => MediaTypes.VideoTypes.Contains(mt));
+                bool hasVideoContent = dto.MediaTypes.Any(mt => MediaTypes.NonAudioTypes.Contains(mt));
                 bool hasAudioContent = dto.MediaTypes.Any(mt => MediaTypes.AudioOnly.Contains(mt));
                 
                 if (hasVideoContent && !hasAudioContent)

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
@@ -10,6 +10,7 @@ using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
+using Jellyfin.Plugin.SmartPlaylist.Constants;
 
 namespace Jellyfin.Plugin.SmartPlaylist
 {
@@ -38,14 +39,15 @@ namespace Jellyfin.Plugin.SmartPlaylist
         {
             return playlists.Where(playlist => 
                 playlist.MediaTypes != null && 
-                playlist.MediaTypes.Any(mediaType => mediaType == "Audio"));
+                playlist.MediaTypes.Any(mediaType => 
+                    MediaTypes.AudioOnly.Contains(mediaType)));
         }
 
         protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
         {
             var query = new InternalItemsQuery(user)
             {
-                IncludeItemTypes = [BaseItemKind.Audio],
+                IncludeItemTypes = [BaseItemKind.Audio, BaseItemKind.AudioBook],
                 Recursive = true
             };
 

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshMediaPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshMediaPlaylistsTask.cs
@@ -13,24 +13,25 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.SmartPlaylist
 {
     /// <summary>
-    /// Scheduled task for refreshing video smart playlists (movies, series, episodes).
+    /// Scheduled task for refreshing media smart playlists (everything except audio/music).
+    /// Handles movies, TV shows, books, photos, music videos, and home videos.
     /// </summary>
-    public class RefreshVideoPlaylistsTask(
+    public class RefreshMediaPlaylistsTask(
         IUserManager userManager,
         ILibraryManager libraryManager,
-        ILogger<RefreshVideoPlaylistsTask> logger,
+        ILogger<RefreshMediaPlaylistsTask> logger,
         IServerApplicationPaths serverApplicationPaths,
         IPlaylistManager playlistManager,
         IUserDataManager userDataManager,
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public override string Name => "Refresh Video/Photo SmartPlaylists";
-        public override string Description => "Refresh all video/photo SmartPlaylists (movies, series, episodes, music videos, home videos, home photos)";
-        public override string Key => "RefreshVideoSmartPlaylists";
+        public override string Name => "Refresh Media Smart Playlists";
+        public override string Description => "Refreshes smart playlists for all media content except audio/music (movies, TV shows, books, music videos, home videos, and photos)";
+        public override string Key => "RefreshMediaSmartPlaylists";
 
         protected override string GetHandledMediaTypes()
         {
-            return "video";
+            return "media";
         }
 
         protected override IEnumerable<SmartPlaylistDto> FilterPlaylistsByMediaType(IEnumerable<SmartPlaylistDto> playlists)
@@ -38,14 +39,14 @@ namespace Jellyfin.Plugin.SmartPlaylist
             return playlists.Where(playlist => 
                 playlist.MediaTypes != null && 
                 playlist.MediaTypes.Any(mediaType => 
-                    MediaTypes.VideoTypes.Contains(mediaType)));
+                    !MediaTypes.AudioOnly.Contains(mediaType)));
         }
 
         protected override IEnumerable<BaseItem> GetRelevantUserMedia(User user)
         {
             var query = new InternalItemsQuery(user)
             {
-                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo],
+                IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Series, BaseItemKind.MusicVideo, BaseItemKind.Video, BaseItemKind.Photo, BaseItemKind.Book],
                 Recursive = true
             };
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requires Jellyfin version `10.10.0` and newer.
 - ⚙️ **Settings** - Configure default settings and trigger a manual refresh for all playlists at any time.
 - 📦 **Export/Import** - Export all playlists to a ZIP file for backup or transfer between Jellyfin instances. Import playlists with duplicate detection.
 - 🛠️ **Advanced Options** - Support for regex patterns, date ranges, and more.
-- 🎵 **Media Types** - Works with movies, series, episodes, music, music videos, home videos and photos.
+- 🎵 **Media Types** - Works with movies, series, episodes, music, music videos, home videos, photos, books (eBooks/Comics), and audiobooks.
 
 ## ⚙️ Configuration
 
@@ -117,8 +117,8 @@ The Export/Import feature allows you to backup your smart playlist configuration
 Smart playlists automatically refresh using scheduled tasks:
 
 #### **Scheduled Tasks**
-- **🎵 Audio SmartPlaylists**: Runs by default daily at **3:30 AM**
-- **🎬 Video SmartPlaylists**: Runs by default **hourly**
+- **🎵 Audio SmartPlaylists**: Runs by default daily at **3:30 AM** (handles music and audiobooks)
+- **🎬 Media SmartPlaylists**: Runs by default **hourly** (handles movies, TV shows, readable books, music videos, home videos, and photos)
 
 These tasks can be configured in the Jellyfin admin dashboard.
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ./media/shows:/shows # You can place some tv/episode files here for testing.
       - ./media/musicvideos:/musicvideos # You can place some music video files here for testing.
       - ./media/music:/music # You can place some music files here for testing.
+      - ./media/books:/books # You can place some books here for testing.
       - ./media/homevideosandphotos:/homevideosandphotos # You can place some home videos and photos here for testing.
       - ../build_output:/config/plugins/SmartPlaylist # Mount the build output directly into the plugins directory.
     restart: "unless-stopped" 


### PR DESCRIPTION
- Updated README to reflect the inclusion of Books and Audiobooks in supported media types.
- Modified PlaylistService to return Books and Audiobooks as valid media types.
- Adjusted RefreshAudioPlaylistsTask and related classes to handle new media types.
- Removed the obsolete RefreshVideoPlaylistsTask as its functionality is now integrated into a unified media task.
- Enhanced MediaTypes constants to include Book and AudioBook types.
- Updated query engine to accommodate new media types and improve item type logging.
- Modified docker-compose configuration to include a directory for testing Books.