### PR TITLE
Fixed rare race condition that could affect the media types of smart playlists

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshPlaylistsTaskBase.cs
@@ -335,7 +335,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
                                 // OPTIMIZATION: Get media specifically for this playlist's media types using cache
                                 // This ensures Movie playlists only get movies, not episodes/series, while avoiding redundant queries
                                 var mediaTypesKey = MediaTypesKey.Create(dto.MediaTypes, dto);
-                                var mediaTypesForClosure = dto.MediaTypes; // Avoid capturing entire dto in closure
+                                var mediaTypesForClosure = dto.MediaTypes?.ToList() ?? []; // Create defensive copy to prevent accidental modifications
                                 // NOTE: Lazy<T> caches exceptions. This is intentional for database operations
                                 // where failures typically indicate serious issues that should fail fast
                                 // rather than retry repeatedly during the same scheduled task execution.

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
             FileName = dto.FileName;
             UserId = dto.UserId;
             Order = OrderFactory.CreateOrder(dto.Order.Name);
-            MediaTypes = dto.MediaTypes ?? [];
+            MediaTypes = dto.MediaTypes != null ? new List<string>(dto.MediaTypes) : []; // Create defensive copy to prevent corruption
             MaxItems = dto.MaxItems ?? 0; // Default to 0 (unlimited) for backwards compatibility
             MaxPlayTimeMinutes = dto.MaxPlayTimeMinutes ?? 0; // Default to 0 (unlimited) for backwards compatibility
 

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
@@ -23,7 +23,16 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public List<ExpressionSet> ExpressionSets { get; set; }
         public OrderDto Order { get; set; }
         public bool Public { get; set; } = false; // Default to private
-        public List<string> MediaTypes { get; set; } = []; // Pre-filter media types
+        private List<string> _mediaTypes = [];
+        
+        /// <summary>
+        /// Pre-filter media types with validation to prevent corruption
+        /// </summary>
+        public List<string> MediaTypes 
+        { 
+            get => _mediaTypes;
+            set => _mediaTypes = value != null ? new List<string>(value) : []; // Always create a defensive copy
+        }
         public bool Enabled { get; set; } = true; // Default to enabled
         public int? MaxItems { get; set; } // Nullable to support backwards compatibility
         public int? MaxPlayTimeMinutes { get; set; } // Nullable to support backwards compatibility


### PR DESCRIPTION
- Updated MediaTypes property in SmartPlaylistDto to ensure a defensive copy is created, preventing potential data corruption.
- Modified SmartPlaylist and RefreshPlaylistsTaskBase to utilize the new defensive copy logic for MediaTypes, enhancing stability and reliability.

Hopefully fixes https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/99