### PR TITLE
You can now sort by play count.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -707,7 +707,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                     new { Value = "ReleaseDate Ascending", Label = "Release Date Ascending" },
                     new { Value = "ReleaseDate Descending", Label = "Release Date Descending" },
                     new { Value = "CommunityRating Ascending", Label = "Community Rating Ascending" },
-                    new { Value = "CommunityRating Descending", Label = "Community Rating Descending" }
+                    new { Value = "CommunityRating Descending", Label = "Community Rating Descending" },
+                    new { Value = "PlayCount (owner) Ascending", Label = "Play Count (owner) Ascending" },
+                    new { Value = "PlayCount (owner) Descending", Label = "Play Count (owner) Descending" }
                 }
             };
 

--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -912,6 +912,7 @@
             { Value: 'CommunityRating', Label: 'Community Rating' },
             { Value: 'DateCreated', Label: 'Date Created' },
             { Value: 'ReleaseDate', Label: 'Release Date' },
+            { Value: 'PlayCount (owner)', Label: 'Play Count (owner)' },
             { Value: 'Resolution', Label: 'Resolution' },
             { Value: 'Random', Label: 'Random' },
             { Value: 'NoOrder', Label: 'No Order' }

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -1713,9 +1713,13 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 }
 
                 // Sort using cached values (no more database calls)
+                // Add DateCreated as tie-breaker for deterministic ordering when values are equal
+                // This puts newer items first when PlayCount is the same, improving discoverability
                 return IsDescending 
                     ? list.OrderByDescending(item => sortValueCache[item])
-                    : list.OrderBy(item => sortValueCache[item]);
+                           .ThenByDescending(item => item.DateCreated)
+                    : list.OrderBy(item => sortValueCache[item])
+                           .ThenByDescending(item => item.DateCreated);
             }
             catch (Exception ex)
             {

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ The plugin uses **.NET regex syntax** (not JavaScript, Perl, or other flavors):
 - **Production Year** - Sort by production year
 - **Community Rating** - Sort by user ratings
 - **Date Created** - Sort by when added to library
+- **Play Count (owner)** - Sort by how many times the playlist owner has played each item
 - **Random** - Randomize the order of items
 - **Ascending** - Oldest first
 - **Descending** - Newest first


### PR DESCRIPTION
- Introduced new sorting options for playlists based on the owner's play count, both in ascending and descending order.
- Updated SmartPlaylistController and configuration files to include the new sorting options.
- Enhanced README documentation to reflect the addition of the Play Count sorting feature.

This update allows users to sort their playlists by how many times they have played each item, improving the overall user experience and playlist management capabilities.

https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/104

## Summary by Sourcery

Introduce PlayCountOrder and PlayCountOrderDesc to sort playlist items by user-specific play counts, update factory, controller, and UI config to include these options, and refresh documentation.

New Features:
- Allow sorting playlists by the owner's play count in ascending order
- Allow sorting playlists by the owner's play count in descending order

Enhancements:
- Add a user-aware OrderBy overload and integrate PlayCountOrder implementations into the OrderFactory
- Expose the new play count sorting options in SmartPlaylistController and the UI configuration

Documentation:
- Document the Play Count sorting feature in the README