### PR TITLE
Fixed issue where playlists could get refreshed that shouldn't.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
@@ -31,6 +31,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         public const string Book = nameof(Book);
         public const string AudioBook = nameof(AudioBook);
         
+        // Fallback Type
+        public const string Unknown = nameof(Unknown);
+        
         /// <summary>
         /// Centralized mapping between BaseItemKind and MediaTypes.
         /// This is the single source of truth for all media type mappings.


### PR DESCRIPTION
## Summary by Sourcery

Add change-type-aware filtering to the playlist auto-refresh logic and update the cache-based and fallback flows to prevent unintended playlist refreshes.

Bug Fixes:
- Prevent playlists from refreshing on irrelevant library or user data changes by applying new filtering logic.

Enhancements:
- Introduce FilterPlaylistsByChangeTypeAsync to centralize change-type and user relevance checks for auto-refresh.
- Refactor GetAffectedPlaylistsFromCacheAsync to call the new filtering method and update logging for library vs user data events.
- Enhance fallback refresh logic to distinguish between library metadata updates and user data changes when evaluating auto-refresh settings.