### PR TITLE
Removed 'Series' media type due to Jellyfin limitations (#120)

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.html
@@ -261,7 +261,7 @@
                             <div id="media-types-container" class="media-type-flex">
                                 <!-- Media type checkboxes will be generated here -->
                             </div>
-                            <div class="fieldDescription">Select the types of media items to include in your playlist. Episodes are individual TV show episodes, while Series are the show containers (shows as a whole). At least one type must be selected.</div>
+                            <div class="fieldDescription">Select the types of media items to include in your playlist. At least one type must be selected.</div>
                         </div>
 
                         <div class="inputContainer">
@@ -414,7 +414,6 @@
                                             <option value="all">All Types</option>
                                             <option value="Movie">Movie</option>
                                             <option value="Episode">Episode</option>
-                                            <option value="Series">Series</option>
                                             <option value="Audio">Audio (Music)</option>
                                             <option value="MusicVideo">Music Video</option>
                                             <option value="Video">Video (Home Video)</option>

--- a/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Constants/MediaTypes.cs
@@ -12,6 +12,10 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
     {
         // TV Types
         public const string Episode = nameof(Episode);
+        
+        // Deprecated: Series media type removed due to Jellyfin playlist limitations
+        // Series objects in playlists are automatically expanded to episodes by Jellyfin,
+        // causing playback issues where only the first series' episodes are playable
         public const string Series = nameof(Series);
         
         // Movie Types  
@@ -41,14 +45,15 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         public static readonly Dictionary<BaseItemKind, string> BaseItemKindToMediaType = new()
         {
             { BaseItemKind.Episode, Episode },
-            { BaseItemKind.Series, Series },
             { BaseItemKind.Movie, Movie },
             { BaseItemKind.Audio, Audio },
             { BaseItemKind.MusicVideo, MusicVideo },
             { BaseItemKind.Video, Video },
             { BaseItemKind.Photo, Photo },
             { BaseItemKind.Book, Book },
-            { BaseItemKind.AudioBook, AudioBook }
+            { BaseItemKind.AudioBook, AudioBook },
+            // Deprecated: Series is kept here only for deserialization so we can validate and reject it properly
+            { BaseItemKind.Series, Series }
         };
         
         /// <summary>
@@ -57,25 +62,28 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         public static readonly Dictionary<string, BaseItemKind> MediaTypeToBaseItemKind = new()
         {
             { Episode, BaseItemKind.Episode },
-            { Series, BaseItemKind.Series },
             { Movie, BaseItemKind.Movie },
             { Audio, BaseItemKind.Audio },
             { MusicVideo, BaseItemKind.MusicVideo },
             { Video, BaseItemKind.Video },
             { Photo, BaseItemKind.Photo },
             { Book, BaseItemKind.Book },
-            { AudioBook, BaseItemKind.AudioBook }
+            { AudioBook, BaseItemKind.AudioBook },
+            // Deprecated: Series is kept here only for deserialization so we can validate and reject it properly
+            { Series, BaseItemKind.Series }
         };
         
         /// <summary>
-        /// Gets all supported media types as an array (derived from centralized mapping)
+        /// Gets all supported media types as an array (excludes deprecated types like Series)
         /// </summary>
-        public static readonly string[] All = [.. BaseItemKindToMediaType.Values];
+        public static readonly string[] All = [.. BaseItemKindToMediaType
+            .Where(static kvp => kvp.Key != BaseItemKind.Series)
+            .Select(static kvp => kvp.Value)];
         
         /// <summary>
         /// Gets non-audio media types (everything except Audio and AudioBook)
         /// </summary>
-        public static readonly string[] NonAudioTypes = [Movie, Series, Episode, MusicVideo, Video, Photo, Book];
+        public static readonly string[] NonAudioTypes = [Movie, Episode, MusicVideo, Video, Photo, Book];
         
         /// <summary>
         /// Gets audio-only media types (Audio, AudioBook)
@@ -88,9 +96,9 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         public static readonly string[] BookTypes = [Book, AudioBook];
         
         /// <summary>
-        /// Gets TV media types (Series, Episode)
+        /// Gets TV media types (Episode only - Series removed due to Jellyfin playlist limitations)
         /// </summary>
-        public static readonly string[] TV = [Series, Episode];
+        public static readonly string[] TV = [Episode];
         
         /// <summary>
         /// Gets music-related media types (Audio, AudioBook, MusicVideo)
@@ -100,7 +108,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Constants
         /// <summary>
         /// Gets media types that can have video streams (excludes Photo, Audio, Book, AudioBook)
         /// </summary>
-        public static readonly string[] VideoStreamCapable = [Movie, Series, Episode, MusicVideo, Video];
+        public static readonly string[] VideoStreamCapable = [Movie, Episode, MusicVideo, Video];
         
         // HashSet variants for O(1) membership checks (performance optimization)
         

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ The plugin features a modern web-based interface for easy playlist management - 
 SmartPlaylist works with all media types supported by Jellyfin:
 
 - **🎬 Movie** - Individual movie files
-- **📺 Series** - TV show series as a whole
 - **📺 Episode** - Individual TV show episodes
 - **🎵 Audio (Music)** - Music tracks and albums
 - **🎬 Music Video** - Music video files
@@ -248,6 +247,8 @@ SmartPlaylist works with all media types supported by Jellyfin:
 - **📸 Photo (Home Photo)** - Personal photos and images
 - **📚 Book** - eBooks, comics, and other readable content
 - **🎧 Audiobook** - Spoken word audio books
+
+> **⚠️ Note**: The "Series" media type has been removed due to Jellyfin playlist limitations, Series objects are not valid in playlists. Use "Episode" media type instead to create TV show playlists with individual episodes.
 
 ### Common Use Cases
 


### PR DESCRIPTION
Updated documentation and error handling to reflect this change. Enhanced media type validation in the playlist service to prevent usage of unsupported types, ensuring a smoother user experience.

## Summary by Sourcery

Remove support for the 'Series' media type across the plugin, enforce validation and rejection of any Series usage, enhance error handling for playlist operations, and update documentation and UI to reflect the removal.

New Features:
- Add validation in PlaylistService to reject deprecated 'Series' media type and enforce selection of at least one media type
- Enhance client-side playlist refresh error handling to parse JSON/text API responses and display detailed messages

Enhancements:
- Remove 'Series' media type from configuration UI, constants, media type lists, and playlist expansion logic
- Update SmartPlaylist constructor to handle null media type lists and simplify internal logic
- Improve default API error message to suggest checking logs

Documentation:
- Remove 'Series' references from README and UI help text and add a warning about its deprecation due to Jellyfin limitations