### PR TITLE
Implement time buffer checks for playlist refresh scheduling

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Api/SmartPlaylistController.cs
@@ -402,7 +402,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.Api
                             var currentMediaType = mediaTypeProperty?.GetValue(jellyfinPlaylist)?.ToString() ?? "Unknown";
                             
                             // Log MediaType for debugging - note this is a known Jellyfin limitation
-                            logger.LogDebug("Created Jellyfin playlist '{PlaylistName}' has MediaType: {MediaType}. Note: Jellyfin defaults to 'Audio' for all playlists regardless of content.", 
+                            logger.LogDebug("Created Jellyfin playlist '{PlaylistName}' has MediaType: {MediaType}.", 
                                 smartPlaylistName, currentMediaType);
                         }
                     }


### PR DESCRIPTION
- Added helper methods to check if the current time is within a 2-minute buffer of a target time and any interval boundary.
- Updated the logic in `IsPlaylistDueForRefresh` to utilize these new methods for daily, weekly, monthly, and interval-based checks.
- Enhanced logging to include seconds in time outputs for better debugging.
- Simplified interval checks by leveraging the new buffer methods for various time intervals.

https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/92

## Summary by Sourcery

Implement time buffer logic for playlist auto-refresh scheduling by introducing helper methods and refactoring daily, weekly, monthly, and interval checks to use a 2-minute buffer, enhance logging with seconds precision, and streamline interval boundary calculations

Enhancements:
- Add IsWithinTimeBuffer and IsWithinIntervalBuffer helper methods for time-based checks
- Refactor daily, weekly, and monthly schedule checks to use the 2-minute time buffer
- Refactor interval schedule checks to use the generic interval buffer method for all interval lengths
- Enhance debug logging to show seconds in timestamps

Chores:
- Remove redundant Jellyfin MediaType limitation note from playlist creation debug log