### PR TITLE
You can now choose to include tags from parent Series for episodes.

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
+++ b/Jellyfin.Plugin.SmartPlaylist/Configuration/config.js
@@ -1868,6 +1868,15 @@
                     <option value="false">No - Only include the series themselves</option>
                     <option value="true">Yes - Include individual episodes from series in collections</option>
                 </select>
+            </div>
+            <div class="rule-tags-options" style="display: none; margin-bottom: 0.75em; padding: 0.5em; background: rgba(255,255,255,0.05); border-radius: 4px;">
+                <label style="display: block; margin-bottom: 0.25em; font-size: 0.85em; color: #ccc; font-weight: 500;">
+                    Include parent series tags:
+                </label>
+                <select is="emby-select" class="emby-select rule-tags-select" style="width: 100%;">
+                    <option value="false">No - Only check episode tags</option>
+                    <option value="true">Yes - Also check tags from parent series</option>
+                </select>
             </div>`;
         
         ruleDiv.innerHTML = fieldsHtml;
@@ -1901,6 +1910,9 @@
         // Initialize Collections options visibility
         updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value);
         
+        // Initialize Tags options visibility
+        updateTagsOptionsVisibility(newRuleRow, fieldSelect.value);
+        
         // Add event listeners with AbortController signal (if supported)
         const listenerOptions = getEventListenerOptions(signal);
         fieldSelect.addEventListener('change', function() {
@@ -1909,6 +1921,7 @@
             updateUserSelectorVisibility(newRuleRow, fieldSelect.value);
             updateNextUnwatchedOptionsVisibility(newRuleRow, fieldSelect.value);
             updateCollectionsOptionsVisibility(newRuleRow, fieldSelect.value);
+            updateTagsOptionsVisibility(newRuleRow, fieldSelect.value);
             updateRegexHelp(newRuleRow);
         }, listenerOptions);
         
@@ -2093,6 +2106,7 @@
                     updateUserSelectorVisibility(ruleRow, currentFieldValue);
                     updateNextUnwatchedOptionsVisibility(ruleRow, currentFieldValue);
                     updateCollectionsOptionsVisibility(ruleRow, currentFieldValue);
+                    updateTagsOptionsVisibility(ruleRow, currentFieldValue);
                 }
                 
                 // Re-add event listeners
@@ -2103,6 +2117,7 @@
                     updateUserSelectorVisibility(ruleRow, fieldSelect.value);
                     updateNextUnwatchedOptionsVisibility(ruleRow, fieldSelect.value);
                     updateCollectionsOptionsVisibility(ruleRow, fieldSelect.value);
+                    updateTagsOptionsVisibility(ruleRow, fieldSelect.value);
                     updateRegexHelp(ruleRow);
                 }, listenerOptions);
                 
@@ -2216,6 +2231,17 @@
                             const includeEpisodesWithinSeries = collectionsSelect.value === 'true';
                             if (includeEpisodesWithinSeries) {
                                 expression.IncludeEpisodesWithinSeries = true;
+                            }
+                            // If false (default), don't include the parameter to save space
+                        }
+                        
+                        // Handle Tags-specific options
+                        const tagsSelect = rule.querySelector('.rule-tags-select');
+                        if (tagsSelect && memberName === 'Tags') {
+                            // Convert string to boolean and only include if it's explicitly true
+                            const includeParentSeriesTags = tagsSelect.value === 'true';
+                            if (includeParentSeriesTags) {
+                                expression.IncludeParentSeriesTags = true;
                             }
                             // If false (default), don't include the parameter to save space
                         }
@@ -2508,6 +2534,24 @@
                 const collectionsSelect = collectionsOptionsDiv.querySelector('.rule-collections-select');
                 if (collectionsSelect) {
                     collectionsSelect.value = 'false'; // Default to not including episodes within series
+                }
+            }
+        }
+    }
+    
+    function updateTagsOptionsVisibility(ruleRow, fieldValue) {
+        const isTagsField = fieldValue === 'Tags';
+        const tagsOptionsDiv = ruleRow.querySelector('.rule-tags-options');
+        
+        if (tagsOptionsDiv) {
+            if (isTagsField) {
+                tagsOptionsDiv.style.display = 'block';
+            } else {
+                tagsOptionsDiv.style.display = 'none';
+                // Reset to default when hiding
+                const tagsSelect = tagsOptionsDiv.querySelector('.rule-tags-select');
+                if (tagsSelect) {
+                    tagsSelect.value = 'false'; // Default to not including parent series tags
                 }
             }
         }
@@ -3015,8 +3059,14 @@
                             collectionsInfo = ' (including episodes within series)';
                         }
                         
+                        // Add Tags configuration info
+                        let tagsInfo = '';
+                        if (rule.MemberName === 'Tags' && rule.IncludeParentSeriesTags === true) {
+                            tagsInfo = ' (including parent series tags)';
+                        }
+                        
                         rulesHtml += '<span style="font-family: monospace; background: #232323; padding: 4px 4px; border-radius: 3px;">';
-                        rulesHtml += escapeHtml(fieldName) + ' ' + escapeHtml(operator) + ' "' + escapeHtml(value) + '"' + escapeHtml(userInfo) + escapeHtml(nextUnwatchedInfo) + escapeHtml(collectionsInfo);
+                        rulesHtml += escapeHtml(fieldName) + ' ' + escapeHtml(operator) + ' "' + escapeHtml(value) + '"' + escapeHtml(userInfo) + escapeHtml(nextUnwatchedInfo) + escapeHtml(collectionsInfo) + escapeHtml(tagsInfo);
                         rulesHtml += '</span>';
                     }
                     rulesHtml += '</div>';
@@ -4459,6 +4509,7 @@
                                 updateUserSelectorVisibility(currentRule, expression.MemberName);
                                 updateNextUnwatchedOptionsVisibility(currentRule, expression.MemberName);
                                 updateCollectionsOptionsVisibility(currentRule, expression.MemberName);
+                                updateTagsOptionsVisibility(currentRule, expression.MemberName);
                                 
                                 // Set value AFTER the correct input type is created
                                 const valueInput = currentRule.querySelector('.rule-value-input');
@@ -4520,6 +4571,16 @@
                                         // Default to false if not specified (backwards compatibility)
                                         const includeValue = expression.IncludeEpisodesWithinSeries === true ? 'true' : 'false';
                                         collectionsSelect.value = includeValue;
+                                    }
+                                }
+                                
+                                if (expression.MemberName === 'Tags') {
+                                    const tagsSelect = currentRule.querySelector('.rule-tags-select');
+                                    if (tagsSelect) {
+                                        // Set the value based on the IncludeParentSeriesTags parameter
+                                        // Default to false if not specified (backwards compatibility)
+                                        const includeValue = expression.IncludeParentSeriesTags === true ? 'true' : 'false';
+                                        tagsSelect.value = includeValue;
                                     }
                                 }
                                 
@@ -4735,6 +4796,7 @@
                 updateUserSelectorVisibility(ruleRow, expression.MemberName);
                 updateNextUnwatchedOptionsVisibility(ruleRow, expression.MemberName);
                 updateCollectionsOptionsVisibility(ruleRow, expression.MemberName);
+                updateTagsOptionsVisibility(ruleRow, expression.MemberName);
             }
             
             if (operatorSelect && expression.Operator) {
@@ -4758,6 +4820,9 @@
                     });
                 }
             }
+            
+            // Update regex help if needed
+            updateRegexHelp(ruleRow);
         } catch (error) {
             console.error('Error populating rule row:', error);
         }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
@@ -20,6 +20,10 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? IncludeEpisodesWithinSeries { get; set; } = null;
         
+        // Tags-specific option - only serialize when meaningful
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? IncludeParentSeriesTags { get; set; } = null;
+        
         // Helper property to check if this is a user-specific expression
         // Only serialize when UserId is not null
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -23,6 +23,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public double DateModified { get; set; } = 0;
         public double ReleaseDate { get; set; } = 0;
         public List<string> Tags { get; set; } = [];
+        public List<string> ParentSeriesTags { get; set; } = [];
         public double RuntimeMinutes { get; set; } = 0;
         public string OfficialRating { get; set; } = "";
         public List<string> AudioLanguages { get; set; } = [];

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshAudioPlaylistsTask.cs
@@ -26,8 +26,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
         IUserDataManager userDataManager,
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public override string Name => "Refresh Audio SmartPlaylists";
-        public override string Description => "Refresh all audio/music SmartPlaylists";
+        public override string Name => "Refresh Audio SmartPlaylists (Legacy)";
+        public override string Description => "Refreshes all legacy audio/music SmartPlaylists that does not use the new individual playlist refresh functionality.";
         public override string Key => "RefreshAudioSmartPlaylists";
 
         protected override string GetHandledMediaTypes()

--- a/Jellyfin.Plugin.SmartPlaylist/RefreshMediaPlaylistsTask.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/RefreshMediaPlaylistsTask.cs
@@ -25,8 +25,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
         IUserDataManager userDataManager,
         IProviderManager providerManager) : RefreshPlaylistsTaskBase(userManager, libraryManager, logger, serverApplicationPaths, playlistManager, userDataManager, providerManager)
     {
-        public override string Name => "Refresh Media SmartPlaylists";
-        public override string Description => "Refreshes smart playlists for all media content except audio/music (movies, TV shows, books, music videos, home videos, and photos)";
+        public override string Name => "Refresh Media SmartPlaylists (Legacy)";
+        public override string Description => "Refreshes all legacy smart playlists for all media content except audio/music, that does not use the new individual playlist refresh functionality.";
         public override string Key => "RefreshMediaSmartPlaylists";
 
         protected override string GetHandledMediaTypes()


### PR DESCRIPTION
- Updated the names and descriptions of the Refresh Audio and Media SmartPlaylists to indicate they are legacy tasks.
- Introduced a new option to include parent series tags in the Tags field, enhancing the filtering capabilities for playlists.
- Added UI elements for configuring the inclusion of parent series tags in the playlist rules.
- Implemented backend logic to handle the extraction and processing of parent series tags, ensuring efficient caching and performance.

https://github.com/jyourstone/jellyfin-smartplaylist-plugin/issues/128